### PR TITLE
[codex] add code reference support to ChatKit

### DIFF
--- a/packages/chatkit-ui/src/components/chat.tsx
+++ b/packages/chatkit-ui/src/components/chat.tsx
@@ -38,6 +38,7 @@ import { ContextUsageIndicator } from './thread/context-usage-indicator';
 import { Button } from './ui/button';
 import { buildInjectedRequestOptions } from '../lib/request-options';
 import {
+  buildHumanMessageInputPayload,
   buildCodeReferencePrompt,
   getCodeReferenceKey,
   getCodeReferenceLabel,
@@ -69,6 +70,7 @@ type UploadedMessageFile = {
 type HumanMessageWithMeta = Message & {
   attachments?: UploadedMessageFile[];
   references?: ChatKitCodeReference[];
+  submittedInput?: string;
 };
 
 function formatMessageContent(content: Message['content'][number]): string {
@@ -506,6 +508,7 @@ export function Chat({
       id: createMessageId(),
       type: 'human',
       content: displayContent,
+      submittedInput,
       ...(filesToSend ? { attachments: filesToSend } : {}),
       ...(referencesToSend ? { references: referencesToSend } : {}),
     };
@@ -775,11 +778,21 @@ export function Chat({
     const messagesUpToIndex = messages.slice(0, messageIndex);
     const lastHumanMessage = [...messagesUpToIndex]
       .reverse()
-      .find((m) => String(m.type) === 'human');
+      .find((message): message is HumanMessageWithMeta => String(message.type) === 'human');
+    const retryInput = lastHumanMessage
+      ? buildHumanMessageInputPayload({
+          content:
+            typeof lastHumanMessage.content === 'string'
+              ? lastHumanMessage.content
+              : '',
+          submittedInput: lastHumanMessage.submittedInput,
+          references: lastHumanMessage.references,
+        })
+      : null;
 
-    if (lastHumanMessage && typeof lastHumanMessage.content === 'string') {
+    if (retryInput) {
       stream.submit(
-        { input: { input: lastHumanMessage.content } },
+        { input: retryInput },
         {
           optimisticValues: (prev) => {
             // Remove the AI message that we're retrying

--- a/packages/chatkit-ui/src/components/chat.tsx
+++ b/packages/chatkit-ui/src/components/chat.tsx
@@ -1,8 +1,20 @@
 import * as React from 'react';
-import { ArrowDown, FileText, Loader2, Pencil, RefreshCw, X } from 'lucide-react';
+import {
+  ArrowDown,
+  FileText,
+  Loader2,
+  Pencil,
+  RefreshCw,
+  X,
+} from 'lucide-react';
 
 import type { Message } from '@xpert-ai/xpert-sdk';
-import type { ChatkitMessage, ChatKitOptions, ToolOption } from '@xpert-ai/chatkit-types';
+import type {
+  ChatkitMessage,
+  ChatKitCodeReference,
+  ChatKitOptions,
+  ToolOption,
+} from '@xpert-ai/chatkit-types';
 
 import { cn, createMessageId } from '../lib/utils';
 import { isNearBottom } from '../lib/scroll';
@@ -14,13 +26,27 @@ import { HistorySidebar } from './history/HistorySidebar';
 import { AssistantMessage } from './thread/messages/ai';
 import { MessageActions } from './thread/MessageActions';
 import { StartScreen } from './thread/StartScreen';
-import { ChatkitAvatar, type ChatkitAvatarData, extractAssistantAvatar } from './ui/chatkit-avatar';
+import {
+  ChatkitAvatar,
+  type ChatkitAvatarData,
+  extractAssistantAvatar,
+} from './ui/chatkit-avatar';
 import { useStreamManager } from '../hooks/useStream';
 import { useThreads } from '../hooks/useThreads';
 import { useChatkitTranslation } from '../i18n/useChatkitTranslation';
 import { ContextUsageIndicator } from './thread/context-usage-indicator';
 import { Button } from './ui/button';
 import { buildInjectedRequestOptions } from '../lib/request-options';
+import {
+  buildCodeReferencePrompt,
+  getCodeReferenceKey,
+  getCodeReferenceLabel,
+  getCodeReferenceRange,
+  mergeCodeReferences,
+  normalizeCodeReferences,
+  type ComposerValuePayload,
+} from '../lib/code-references';
+import { useParentMessenger } from '../hooks/useParentMessenger';
 
 export type ChatProps = {
   className?: string;
@@ -31,7 +57,19 @@ export type ChatProps = {
   isClientSecretInitializing?: boolean;
 };
 
-const defaultApiUrl = import.meta.env.VITE_XPERTAI_API_URL as string | undefined;
+const defaultApiUrl = import.meta.env.VITE_XPERTAI_API_URL as
+  | string
+  | undefined;
+
+type UploadedMessageFile = {
+  originalName: string;
+  mimetype: string;
+};
+
+type HumanMessageWithMeta = Message & {
+  attachments?: UploadedMessageFile[];
+  references?: ChatKitCodeReference[];
+};
 
 function formatMessageContent(content: Message['content'][number]): string {
   if (typeof content === 'string') {
@@ -62,6 +100,10 @@ function formatMessageContent(content: Message['content'][number]): string {
   return '';
 }
 
+function formatCodeReferenceTitle(reference: ChatKitCodeReference): string {
+  return `${reference.path}:${getCodeReferenceRange(reference)}`;
+}
+
 export function Chat({
   className,
   options,
@@ -76,13 +118,14 @@ export function Chat({
   const history = options?.history;
   const disclaimer = options?.disclaimer;
   const apiUrl = options?.api?.apiUrl || defaultApiUrl;
-  const {setStream} = useStreamManager();
+  const { setStream } = useStreamManager();
   const stream = useStreamContext();
 
   const [isHistoryLoading, setIsHistoryLoading] = React.useState(false);
   const [historyError, setHistoryError] = React.useState<string | null>(null);
   const [assistantName, setAssistantName] = React.useState<string | null>(null);
-  const [assistantAvatar, setAssistantAvatar] = React.useState<ChatkitAvatarData | null>(null);
+  const [assistantAvatar, setAssistantAvatar] =
+    React.useState<ChatkitAvatarData | null>(null);
 
   // Minimum loading dots display time (ms)
   const LOADING_DOTS_MIN_DURATION = 800;
@@ -124,8 +167,13 @@ export function Chat({
   }, [stream.isLoading]);
 
   const [draft, setDraft] = React.useState('');
-  const [selectedTool, setSelectedTool] = React.useState<ToolOption | null>(null);
+  const [selectedTool, setSelectedTool] = React.useState<ToolOption | null>(
+    null,
+  );
   const [attachments, setAttachments] = React.useState<UploadingFile[]>([]);
+  const [references, setReferences] = React.useState<ChatKitCodeReference[]>(
+    [],
+  );
   const [isAtBottom, setIsAtBottom] = React.useState(true);
   const [hasUpdatesBelow, setHasUpdatesBelow] = React.useState(false);
   const {
@@ -136,6 +184,7 @@ export function Chat({
   } = useThreads();
   const viewportRef = React.useRef<HTMLDivElement>(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const composerInputRef = React.useRef<HTMLInputElement>(null);
   const shouldAutoScrollRef = React.useRef(true);
   const forceFollowRef = React.useRef(false);
   const previousMessageCountRef = React.useRef(0);
@@ -149,10 +198,53 @@ export function Chat({
 
   // Use placeholder from composer options or fallback to prop/i18n
   const inputPlaceholder =
-    selectedTool?.placeholderOverride ?? composer?.placeholder ?? resolvedPlaceholder;
+    selectedTool?.placeholderOverride ??
+    composer?.placeholder ??
+    resolvedPlaceholder;
 
-  const messages = React.useMemo(() => stream.messages ?? [], [stream.messages]);
+  const messages = React.useMemo(
+    () => stream.messages ?? [],
+    [stream.messages],
+  );
   const trimmedDraft = draft.trim();
+  const hasReferences = references.length > 0;
+
+  useParentMessenger({
+    onSetComposerValue: React.useCallback(
+      (payload: ComposerValuePayload | null) => {
+        if (!payload) {
+          return;
+        }
+
+        if (typeof payload.text === 'string') {
+          setDraft(payload.text);
+        }
+
+        if (Array.isArray(payload.references)) {
+          const nextReferences = normalizeCodeReferences(payload.references);
+          setReferences((previous) =>
+            payload.appendReferences
+              ? mergeCodeReferences(previous, nextReferences)
+              : nextReferences,
+          );
+        }
+
+        if (payload.selectedToolId !== undefined) {
+          const nextTool =
+            payload.selectedToolId === null
+              ? null
+              : ((composer?.tools ?? []).find(
+                  (tool) => tool.id === payload.selectedToolId,
+                ) ?? null);
+          setSelectedTool(nextTool);
+        }
+      },
+      [composer?.tools],
+    ),
+    onFocusComposer: React.useCallback(() => {
+      composerInputRef.current?.focus();
+    }, []),
+  });
 
   const cancelPendingAutoScroll = React.useCallback(() => {
     if (autoScrollFrameRef.current !== null) {
@@ -173,30 +265,33 @@ export function Chat({
     setHasUpdatesBelow(false);
   }, []);
 
-  const scrollToBottom = React.useCallback((smooth = false, force = false) => {
-    if (force) {
-      enableAutoFollow();
-    }
-
-    cancelPendingAutoScroll();
-
-    // Use requestAnimationFrame to ensure DOM has updated
-    autoScrollFrameRef.current = requestAnimationFrame(() => {
-      autoScrollFrameRef.current = null;
-
-      const viewport = viewportRef.current;
-      if (viewport) {
-        if (!force && !shouldAutoScrollRef.current) {
-          return;
-        }
-
-        viewport.scrollTo({
-          top: viewport.scrollHeight,
-          behavior: smooth ? 'smooth' : 'instant',
-        });
+  const scrollToBottom = React.useCallback(
+    (smooth = false, force = false) => {
+      if (force) {
+        enableAutoFollow();
       }
-    });
-  }, [cancelPendingAutoScroll, enableAutoFollow]);
+
+      cancelPendingAutoScroll();
+
+      // Use requestAnimationFrame to ensure DOM has updated
+      autoScrollFrameRef.current = requestAnimationFrame(() => {
+        autoScrollFrameRef.current = null;
+
+        const viewport = viewportRef.current;
+        if (viewport) {
+          if (!force && !shouldAutoScrollRef.current) {
+            return;
+          }
+
+          viewport.scrollTo({
+            top: viewport.scrollHeight,
+            behavior: smooth ? 'smooth' : 'instant',
+          });
+        }
+      });
+    },
+    [cancelPendingAutoScroll, enableAutoFollow],
+  );
 
   React.useEffect(() => {
     const viewport = viewportRef.current;
@@ -267,13 +362,23 @@ export function Chat({
 
     updateAutoScrollState();
     viewport.addEventListener('wheel', handleWheel, { passive: true });
-    viewport.addEventListener('pointerdown', handlePointerDown, { passive: true });
-    viewport.addEventListener('scroll', updateAutoScrollState, { passive: true });
-    viewport.addEventListener('touchstart', handleTouchStart, { passive: true });
+    viewport.addEventListener('pointerdown', handlePointerDown, {
+      passive: true,
+    });
+    viewport.addEventListener('scroll', updateAutoScrollState, {
+      passive: true,
+    });
+    viewport.addEventListener('touchstart', handleTouchStart, {
+      passive: true,
+    });
     viewport.addEventListener('touchmove', handleTouchMove, { passive: true });
     viewport.addEventListener('touchend', handleTouchEnd, { passive: true });
-    window.addEventListener('pointerup', stopPointerTracking, { passive: true });
-    window.addEventListener('pointercancel', stopPointerTracking, { passive: true });
+    window.addEventListener('pointerup', stopPointerTracking, {
+      passive: true,
+    });
+    window.addEventListener('pointercancel', stopPointerTracking, {
+      passive: true,
+    });
 
     return () => {
       cancelPendingAutoScroll();
@@ -297,7 +402,8 @@ export function Chat({
   }, [stream.threadId]);
 
   React.useEffect(() => {
-    const messageCountChanged = messages.length !== previousMessageCountRef.current;
+    const messageCountChanged =
+      messages.length !== previousMessageCountRef.current;
     previousMessageCountRef.current = messages.length;
 
     if (!shouldAutoScrollRef.current) {
@@ -312,14 +418,20 @@ export function Chat({
     }
   }, [stream.isLoading, messages, scrollToBottom]);
 
-  const effectiveClientSecret = stream.apiKey?.trim() ? stream.apiKey : clientSecret;
+  const effectiveClientSecret = stream.apiKey?.trim()
+    ? stream.apiKey
+    : clientSecret;
   const hasApiKey = Boolean(effectiveClientSecret.trim());
   const missingConfig = !apiUrl || !hasApiKey;
   const showMissingConfig = !isClientSecretInitializing && missingConfig;
   // Check if any files are still uploading (moved up for use in isSendDisabled)
   const hasUploadingFiles = attachments.some((a) => a.status === 'uploading');
   const isSendDisabled =
-    !trimmedDraft || stream.isLoading || missingConfig || isHistoryLoading || hasUploadingFiles;
+    (!trimmedDraft && !hasReferences) ||
+    stream.isLoading ||
+    missingConfig ||
+    isHistoryLoading ||
+    hasUploadingFiles;
 
   React.useEffect(() => {
     if (missingConfig) return;
@@ -343,7 +455,8 @@ export function Chat({
       .then((assistant) => {
         if (cancelled || !assistant) return;
         const assistantTitle =
-          typeof assistant.metadata?.title === 'string' && assistant.metadata.title.trim()
+          typeof assistant.metadata?.title === 'string' &&
+          assistant.metadata.title.trim()
             ? assistant.metadata.title
             : assistant.name;
         setAssistantName(assistantTitle);
@@ -378,23 +491,40 @@ export function Chat({
     if (isSendDisabled) return;
 
     // Store files for display in the message
-    const filesToSend = uploadedFiles.length > 0 ? [...uploadedFiles] : undefined;
+    const filesToSend =
+      uploadedFiles.length > 0 ? [...uploadedFiles] : undefined;
+    const referencesToSend =
+      references.length > 0 ? [...references] : undefined;
+    const submittedInput = buildCodeReferencePrompt(
+      trimmedDraft,
+      referencesToSend ?? [],
+    );
+    const displayContent =
+      trimmedDraft || (referencesToSend ? t('chat.referencedCodeOnly') : '');
 
-    const newMessage: Message & { attachments?: typeof uploadedFiles } = {
+    const newMessage: HumanMessageWithMeta = {
       id: createMessageId(),
       type: 'human',
-      content: trimmedDraft,
+      content: displayContent,
       ...(filesToSend ? { attachments: filesToSend } : {}),
+      ...(referencesToSend ? { references: referencesToSend } : {}),
     };
 
     setDraft('');
 
     // Include files in the submit request
-    const inputPayload: { input: string; files?: typeof uploadedFiles } = {
-      input: trimmedDraft,
+    const inputPayload: {
+      input: string;
+      files?: typeof uploadedFiles;
+      references?: ChatKitCodeReference[];
+    } = {
+      input: submittedInput,
     };
     if (filesToSend) {
       inputPayload.files = filesToSend;
+    }
+    if (referencesToSend) {
+      inputPayload.references = referencesToSend;
     }
 
     const requestOptions = buildInjectedRequestOptions({
@@ -426,6 +556,7 @@ export function Chat({
     }
     // Clear attachments after submit
     setAttachments([]);
+    setReferences([]);
   };
 
   const handleAttachmentClick = () => {
@@ -433,45 +564,53 @@ export function Chat({
   };
 
   // Upload a single file to the server
-  const uploadFile = React.useCallback(async (localId: string, file: File) => {
-    try {
-      const result = await stream.client.contexts.uploadFile<StorageFile>(file);
-      setAttachments((prev) =>
-        prev.map((item) =>
-          item.localId === localId
-            ? { ...item, status: 'success' as const, storageFile: result }
-            : item
-        )
-      );
-    } catch (error) {
-      setAttachments((prev) =>
-        prev.map((item) =>
-          item.localId === localId
-            ? {
-                ...item,
-                status: 'error' as const,
-                error: error instanceof Error ? error.message : 'Upload failed',
-              }
-            : item
-        )
-      );
-    }
-  }, [stream.client]);
+  const uploadFile = React.useCallback(
+    async (localId: string, file: File) => {
+      try {
+        const result =
+          await stream.client.contexts.uploadFile<StorageFile>(file);
+        setAttachments((prev) =>
+          prev.map((item) =>
+            item.localId === localId
+              ? { ...item, status: 'success' as const, storageFile: result }
+              : item,
+          ),
+        );
+      } catch (error) {
+        setAttachments((prev) =>
+          prev.map((item) =>
+            item.localId === localId
+              ? {
+                  ...item,
+                  status: 'error' as const,
+                  error:
+                    error instanceof Error ? error.message : 'Upload failed',
+                }
+              : item,
+          ),
+        );
+      }
+    },
+    [stream.client],
+  );
 
   // Retry uploading a failed file
-  const handleRetryUpload = React.useCallback((localId: string) => {
-    const attachment = attachments.find((a) => a.localId === localId);
-    if (!attachment || attachment.status !== 'error') return;
+  const handleRetryUpload = React.useCallback(
+    (localId: string) => {
+      const attachment = attachments.find((a) => a.localId === localId);
+      if (!attachment || attachment.status !== 'error') return;
 
-    setAttachments((prev) =>
-      prev.map((item) =>
-        item.localId === localId
-          ? { ...item, status: 'uploading' as const, error: undefined }
-          : item
-      )
-    );
-    void uploadFile(localId, attachment.file);
-  }, [attachments, uploadFile]);
+      setAttachments((prev) =>
+        prev.map((item) =>
+          item.localId === localId
+            ? { ...item, status: 'uploading' as const, error: undefined }
+            : item,
+        ),
+      );
+      void uploadFile(localId, attachment.file);
+    },
+    [attachments, uploadFile],
+  );
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
@@ -517,12 +656,15 @@ export function Chat({
     // If file was uploaded successfully, delete from server
     if (attachment.status === 'success' && attachment.storageFile?.id) {
       try {
-        await fetch(`${stream.apiUrl}/contexts/file/${attachment.storageFile.id}`, {
-          method: 'DELETE',
-          headers: {
-            'Authorization': `Bearer ${effectiveClientSecret}`,
+        await fetch(
+          `${stream.apiUrl}/contexts/file/${attachment.storageFile.id}`,
+          {
+            method: 'DELETE',
+            headers: {
+              Authorization: `Bearer ${effectiveClientSecret}`,
+            },
           },
-        });
+        );
       } catch {
         // Still remove from local state even if server delete fails
       }
@@ -631,13 +773,13 @@ export function Chat({
   const handleRetry = (messageIndex: number) => {
     // Find the last human message before this AI message to resend
     const messagesUpToIndex = messages.slice(0, messageIndex);
-    const lastHumanMessage = [...messagesUpToIndex].reverse().find(
-      (m) => String(m.type) === 'human'
-    );
+    const lastHumanMessage = [...messagesUpToIndex]
+      .reverse()
+      .find((m) => String(m.type) === 'human');
 
     if (lastHumanMessage && typeof lastHumanMessage.content === 'string') {
       stream.submit(
-        { input: {input: lastHumanMessage.content} },
+        { input: { input: lastHumanMessage.content } },
         {
           optimisticValues: (prev) => {
             // Remove the AI message that we're retrying
@@ -677,7 +819,8 @@ export function Chat({
   const assistantTitle = assistantName || resolvedTitle;
 
   return (
-    <div ref={viewportRef}
+    <div
+      ref={viewportRef}
       className={cn(
         'relative flex h-full w-full flex-col flex-1 overflow-y-auto bg-background shadow-sm',
         className,
@@ -693,15 +836,20 @@ export function Chat({
             />
             <span className="absolute bottom-0 right-0 h-2.5 w-2.5 rounded-full border-2 border-background bg-green-500" />
           </div>
-          <div className='truncate'>
-            <h2 className="text-lg font-semibold truncate" title={assistantTitle}>
+          <div className="truncate">
+            <h2
+              className="text-lg font-semibold truncate"
+              title={assistantTitle}
+            >
               {assistantTitle}
             </h2>
-            <p className="text-xs text-muted-foreground">{t('chat.statusOnline')}</p>
+            <p className="text-xs text-muted-foreground">
+              {t('chat.statusOnline')}
+            </p>
           </div>
         </div>
         {/* History controls - only shown when history.enabled is true (default) */}
-        {(history?.enabled !== false) && (
+        {history?.enabled !== false && (
           <div className="flex items-center gap-1">
             {/* New thread button */}
             <button
@@ -712,7 +860,7 @@ export function Chat({
                 'flex h-8 w-8 cursor-pointer items-center justify-center rounded-md',
                 'text-muted-foreground hover:text-foreground hover:bg-muted',
                 'transition-colors duration-150',
-                'disabled:opacity-50 disabled:cursor-not-allowed'
+                'disabled:opacity-50 disabled:cursor-not-allowed',
               )}
               title={t('history.newThread')}
             >
@@ -768,8 +916,13 @@ export function Chat({
                 typeof message.content === 'string'
                   ? message.content
                   : Array.isArray(message.content)
-                    ? message.content.map((part) => formatMessageContent(part as any)).join('')
+                    ? message.content
+                        .map((part) => formatMessageContent(part as any))
+                        .join('')
                     : formatMessageContent(message.content);
+              const humanMessage = message as HumanMessageWithMeta;
+              const humanReferences = humanMessage.references ?? [];
+              const humanAttachments = humanMessage.attachments ?? [];
 
               return (
                 <div
@@ -778,7 +931,7 @@ export function Chat({
                     'group flex gap-3',
                     message.type === 'human'
                       ? 'justify-end'
-                      : 'justify-start -ml-1',  // AI messages: slightly closer to left
+                      : 'justify-start -ml-1', // AI messages: slightly closer to left
                   )}
                 >
                   <div className="flex flex-col px-3 overflow-hidden">
@@ -789,7 +942,7 @@ export function Chat({
                           ? 'bg-primary text-primary-foreground px-4 py-2.5'
                           : message.type === 'system'
                             ? 'bg-muted text-muted-foreground text-xs px-4 py-2.5'
-                            : 'py-1 text-chat-foreground',  // AI messages: use chat-specific foreground color
+                            : 'py-1 text-chat-foreground', // AI messages: use chat-specific foreground color
                       )}
                     >
                       {isAssistantMessage ? (
@@ -798,24 +951,46 @@ export function Chat({
                             ...(message as ChatkitMessage),
                             type: 'assistant',
                           }}
-                          isStreaming={stream.isLoading && index === messages.length - 1}
+                          isStreaming={
+                            stream.isLoading && index === messages.length - 1
+                          }
                         />
                       ) : (
                         <>
+                          {message.type === 'human' &&
+                            humanReferences.length > 0 && (
+                              <div className="mb-2 flex flex-wrap gap-1.5">
+                                {humanReferences.map((reference) => (
+                                  <div
+                                    key={getCodeReferenceKey(reference)}
+                                    className="flex items-center gap-1.5 rounded-md bg-primary-foreground/20 px-2 py-1 text-xs"
+                                    title={`${formatCodeReferenceTitle(reference)}\n\n${reference.text}`}
+                                  >
+                                    <FileText size={12} />
+                                    <span className="max-w-[180px] truncate">
+                                      {getCodeReferenceLabel(reference)}
+                                    </span>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
                           {/* Show attachments for human messages */}
-                          {message.type === 'human' && (message as any).attachments?.length > 0 && (
-                            <div className="flex flex-wrap gap-1.5 mb-2">
-                              {((message as any).attachments as Array<{ originalName: string; mimetype: string }>).map((file, fileIndex) => (
-                                <div
-                                  key={fileIndex}
-                                  className="flex items-center gap-1.5 rounded-md bg-primary-foreground/20 px-2 py-1 text-xs"
-                                >
-                                  <FileText size={12} />
-                                  <span className="max-w-[100px] truncate">{file.originalName}</span>
-                                </div>
-                              ))}
-                            </div>
-                          )}
+                          {message.type === 'human' &&
+                            humanAttachments.length > 0 && (
+                              <div className="flex flex-wrap gap-1.5 mb-2">
+                                {humanAttachments.map((file, fileIndex) => (
+                                  <div
+                                    key={fileIndex}
+                                    className="flex items-center gap-1.5 rounded-md bg-primary-foreground/20 px-2 py-1 text-xs"
+                                  >
+                                    <FileText size={12} />
+                                    <span className="max-w-[100px] truncate">
+                                      {file.originalName}
+                                    </span>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
                           {Array.isArray(message.content) ? (
                             message.content.map((part, partIndex) => (
                               <p
@@ -837,9 +1012,13 @@ export function Chat({
                     <MessageActions
                       content={messageContent}
                       isAssistant={isAssistantMessage}
-                      isStreaming={stream.isLoading && index === messages.length - 1}
+                      isStreaming={
+                        stream.isLoading && index === messages.length - 1
+                      }
                       onRetry={
-                        isAssistantMessage && !stream.isLoading && index === messages.length - 1
+                        isAssistantMessage &&
+                        !stream.isLoading &&
+                        index === messages.length - 1
                           ? () => handleRetry(index)
                           : undefined
                       }
@@ -849,28 +1028,35 @@ export function Chat({
               );
             })}
             {/* Show loading indicator with minimum display time */}
-            {showLoadingDots && (() => {
-              const lastMessage = messages[messages.length - 1];
-              const lastMessageType = lastMessage ? String(lastMessage.type) : '';
-              const isLastMessageFromAI = lastMessageType === 'ai' || lastMessageType === 'assistant';
-              // Hide dots once AI has substantial content
-              const lastMsgContent = lastMessage?.content;
-              const hasSubstantialContent = isLastMessageFromAI &&
-                ((typeof lastMsgContent === 'string' && lastMsgContent.length > 10) ||
-                  (Array.isArray(lastMsgContent) && lastMsgContent.length > 0));
-              if (hasSubstantialContent) return null;
-              return (
-                <div className="flex justify-start gap-3 -ml-2">
-                  <div className="max-w-full rounded-2xl py-2.5">
-                    <div className="flex gap-1.5">
-                      <div className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:-0.3s]"></div>
-                      <div className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:-0.15s]"></div>
-                      <div className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground/60"></div>
+            {showLoadingDots &&
+              (() => {
+                const lastMessage = messages[messages.length - 1];
+                const lastMessageType = lastMessage
+                  ? String(lastMessage.type)
+                  : '';
+                const isLastMessageFromAI =
+                  lastMessageType === 'ai' || lastMessageType === 'assistant';
+                // Hide dots once AI has substantial content
+                const lastMsgContent = lastMessage?.content;
+                const hasSubstantialContent =
+                  isLastMessageFromAI &&
+                  ((typeof lastMsgContent === 'string' &&
+                    lastMsgContent.length > 10) ||
+                    (Array.isArray(lastMsgContent) &&
+                      lastMsgContent.length > 0));
+                if (hasSubstantialContent) return null;
+                return (
+                  <div className="flex justify-start gap-3 -ml-2">
+                    <div className="max-w-full rounded-2xl py-2.5">
+                      <div className="flex gap-1.5">
+                        <div className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:-0.3s]"></div>
+                        <div className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:-0.15s]"></div>
+                        <div className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground/60"></div>
+                      </div>
                     </div>
                   </div>
-                </div>
-              );
-            })()}
+                );
+              })()}
           </div>
         )}
       </div>
@@ -883,7 +1069,7 @@ export function Chat({
             variant={hasUpdatesBelow ? 'default' : 'outline'}
             className={cn(
               'pointer-events-auto rounded-full shadow-md dark:border-white/20 dark:ring-1 dark:ring-white/15 dark:shadow-[0_0_0_1px_rgba(255,255,255,0.06),0_10px_30px_rgba(0,0,0,0.45)]',
-              hasUpdatesBelow && 'animate-bounce'
+              hasUpdatesBelow && 'animate-bounce',
             )}
             onClick={() => scrollToBottom(true, true)}
             aria-label={t('chat.scrollToBottom')}
@@ -917,13 +1103,18 @@ export function Chat({
               <div
                 key={item.localId}
                 className={cn(
-                  "flex items-center gap-2 rounded-md px-2 py-1 text-sm",
-                  item.status === 'error' ? 'bg-destructive/10 border border-destructive/30' : 'bg-muted'
+                  'flex items-center gap-2 rounded-md px-2 py-1 text-sm',
+                  item.status === 'error'
+                    ? 'bg-destructive/10 border border-destructive/30'
+                    : 'bg-muted',
                 )}
               >
                 {/* Status icon */}
                 {item.status === 'uploading' && (
-                  <Loader2 size={14} className="animate-spin text-muted-foreground" />
+                  <Loader2
+                    size={14}
+                    className="animate-spin text-muted-foreground"
+                  />
                 )}
                 {item.status === 'success' && (
                   <FileText size={14} className="text-muted-foreground" />
@@ -933,10 +1124,12 @@ export function Chat({
                 )}
 
                 {/* File name */}
-                <span className={cn(
-                  "max-w-30 truncate",
-                  item.status === 'error' && 'text-destructive'
-                )}>
+                <span
+                  className={cn(
+                    'max-w-30 truncate',
+                    item.status === 'error' && 'text-destructive',
+                  )}
+                >
                   {item.file.name}
                 </span>
 
@@ -957,11 +1150,45 @@ export function Chat({
                   type="button"
                   onClick={() => handleRemoveAttachment(item.localId)}
                   className={cn(
-                    "ml-1 rounded-full p-0.5",
+                    'ml-1 rounded-full p-0.5',
                     item.status === 'error'
                       ? 'text-destructive hover:bg-destructive/20'
-                      : 'hover:bg-muted-foreground/20'
+                      : 'hover:bg-muted-foreground/20',
                   )}
+                >
+                  <X size={12} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {references.length > 0 && (
+          <div className="mb-3 flex flex-wrap gap-2">
+            {references.map((reference) => (
+              <div
+                key={getCodeReferenceKey(reference)}
+                className="flex items-center gap-2 rounded-md bg-muted px-2 py-1 text-sm"
+                title={`${formatCodeReferenceTitle(reference)}\n\n${reference.text}`}
+              >
+                <FileText size={14} className="text-muted-foreground" />
+                <span className="max-w-40 truncate">
+                  {getCodeReferenceLabel(reference)}
+                </span>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setReferences((previous) =>
+                      previous.filter(
+                        (item) =>
+                          getCodeReferenceKey(item) !==
+                          getCodeReferenceKey(reference),
+                      ),
+                    )
+                  }
+                  className="ml-1 rounded-full p-0.5 hover:bg-muted-foreground/20"
+                  title={t('composer.removeReference')}
+                  aria-label={t('composer.removeReference')}
                 >
                   <X size={12} />
                 </button>
@@ -994,7 +1221,7 @@ export function Chat({
               'bg-background border border-border shadow-sm',
               'pl-1.5 pr-1.5 py-1',
               'focus-within:border-muted-foreground/30 focus-within:shadow-md',
-              'transition-shadow duration-200'
+              'transition-shadow duration-200',
             )}
           >
             {/* Plus button inside input - left side */}
@@ -1006,6 +1233,7 @@ export function Chat({
               disabled={stream.isLoading || missingConfig || isHistoryLoading}
             />
             <input
+              ref={composerInputRef}
               type="text"
               value={draft}
               onChange={(event) => setDraft(event.target.value)}
@@ -1014,7 +1242,7 @@ export function Chat({
               className={cn(
                 'flex-1 bg-transparent text-sm text-foreground outline-none pr-2',
                 'placeholder:text-muted-foreground',
-                'disabled:cursor-not-allowed disabled:opacity-50'
+                'disabled:cursor-not-allowed disabled:opacity-50',
               )}
               autoComplete="off"
             />
@@ -1033,7 +1261,9 @@ export function Chat({
           <p
             className={cn(
               'mt-2 text-center text-xs',
-              disclaimer.highContrast ? 'text-foreground' : 'text-muted-foreground'
+              disclaimer.highContrast
+                ? 'text-foreground'
+                : 'text-muted-foreground',
             )}
           >
             {disclaimer.text}

--- a/packages/chatkit-ui/src/hooks/useParentMessenger.tsx
+++ b/packages/chatkit-ui/src/hooks/useParentMessenger.tsx
@@ -1,28 +1,53 @@
-import { useContext, useEffect, useRef } from "react";
-import type { ChatKitOptions } from "@xpert-ai/chatkit-types";
-import { ParentMessengerContext, type ParentMessenger } from "../providers/ParentMessenger";
+import { useContext, useEffect, useRef } from 'react';
+import type { ChatKitOptions } from '@xpert-ai/chatkit-types';
+import {
+  ParentMessengerContext,
+  type ParentMessenger,
+} from '../providers/ParentMessenger';
+import type { ComposerValuePayload } from '../lib/code-references';
 
-export type { ParentMessenger } from "../providers/ParentMessenger";
+export type { ParentMessenger } from '../providers/ParentMessenger';
 
 export type ParentMessengerOptions = {
   onSetOptions?: (options: ChatKitOptions | null) => void;
+  onSetComposerValue?: (payload: ComposerValuePayload | null) => void;
+  onFocusComposer?: () => void;
 };
 
-export function useParentMessenger(
-  { onSetOptions }: ParentMessengerOptions = {},
-): ParentMessenger {
+export function useParentMessenger({
+  onSetOptions,
+  onSetComposerValue,
+  onFocusComposer,
+}: ParentMessengerOptions = {}): ParentMessenger {
   const context = useContext(ParentMessengerContext);
   if (!context) {
-    throw new Error("useParentMessenger must be used within a ParentMessengerProvider");
+    throw new Error(
+      'useParentMessenger must be used within a ParentMessengerProvider',
+    );
   }
 
-  const { registerOnSetOptions, ...messenger } = context;
+  const {
+    registerOnSetOptions,
+    registerOnSetComposerValue,
+    registerOnFocusComposer,
+    ...messenger
+  } = context;
   const onSetOptionsRef = useRef(onSetOptions);
+  const onSetComposerValueRef = useRef(onSetComposerValue);
+  const onFocusComposerRef = useRef(onFocusComposer);
   useEffect(() => {
     onSetOptionsRef.current = onSetOptions;
   }, [onSetOptions]);
+  useEffect(() => {
+    onSetComposerValueRef.current = onSetComposerValue;
+  }, [onSetComposerValue]);
+  useEffect(() => {
+    onFocusComposerRef.current = onFocusComposer;
+  }, [onFocusComposer]);
 
   const hasOnSetOptions = Boolean(onSetOptions);
+  const hasOnSetComposerValue = Boolean(onSetComposerValue);
+  const hasOnFocusComposer = Boolean(onFocusComposer);
   useEffect(() => {
     if (!hasOnSetOptions) return;
     const handler = (options: ChatKitOptions | null) => {
@@ -30,6 +55,22 @@ export function useParentMessenger(
     };
     return registerOnSetOptions(handler);
   }, [hasOnSetOptions, registerOnSetOptions]);
+
+  useEffect(() => {
+    if (!hasOnSetComposerValue) return;
+    const handler = (payload: ComposerValuePayload | null) => {
+      onSetComposerValueRef.current?.(payload);
+    };
+    return registerOnSetComposerValue(handler);
+  }, [hasOnSetComposerValue, registerOnSetComposerValue]);
+
+  useEffect(() => {
+    if (!hasOnFocusComposer) return;
+    const handler = () => {
+      onFocusComposerRef.current?.();
+    };
+    return registerOnFocusComposer(handler);
+  }, [hasOnFocusComposer, registerOnFocusComposer]);
 
   return messenger;
 }

--- a/packages/chatkit-ui/src/i18n/locales/en-US.json
+++ b/packages/chatkit-ui/src/i18n/locales/en-US.json
@@ -10,6 +10,7 @@
     "send": "Send message",
     "scrollToBottom": "Scroll to bottom",
     "retryUpload": "Retry upload",
+    "referencedCodeOnly": "Referenced code",
     "poweredBy": "Powered by Xpert AI",
     "errors": {
       "loadMessages": "Failed to load thread messages",
@@ -41,7 +42,8 @@
   },
   "composer": {
     "openMenu": "Open menu",
-    "addAttachment": "Add attachment"
+    "addAttachment": "Add attachment",
+    "removeReference": "Remove reference"
   },
   "sheet": {
     "close": "Close"

--- a/packages/chatkit-ui/src/i18n/locales/zh-CN.json
+++ b/packages/chatkit-ui/src/i18n/locales/zh-CN.json
@@ -10,6 +10,7 @@
     "send": "发送消息",
     "scrollToBottom": "回到底部",
     "retryUpload": "重新上传",
+    "referencedCodeOnly": "已引用代码",
     "poweredBy": "由 Xpert AI 驱动",
     "errors": {
       "loadMessages": "加载线程消息失败",
@@ -41,7 +42,8 @@
   },
   "composer": {
     "openMenu": "打开菜单",
-    "addAttachment": "添加附件"
+    "addAttachment": "添加附件",
+    "removeReference": "移除引用"
   },
   "sheet": {
     "close": "关闭"

--- a/packages/chatkit-ui/src/lib/code-references.test.ts
+++ b/packages/chatkit-ui/src/lib/code-references.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCodeReferencePrompt,
+  buildHumanMessageInputPayload,
+} from './code-references';
+
+const references = [
+  {
+    path: 'src/app.ts',
+    startLine: 10,
+    endLine: 14,
+    text: 'console.log("hello");',
+    language: 'ts',
+  },
+];
+
+describe('buildHumanMessageInputPayload', () => {
+  it('prefers the submitted input when a human message stores display-only content', () => {
+    const submittedInput = buildCodeReferencePrompt('', references);
+
+    expect(
+      buildHumanMessageInputPayload({
+        content: 'Referenced code',
+        submittedInput,
+        references,
+      }),
+    ).toEqual({
+      input: submittedInput,
+      references,
+    });
+  });
+
+  it('rebuilds the reference prompt when submitted input is not stored yet', () => {
+    expect(
+      buildHumanMessageInputPayload({
+        content: 'Please review this change',
+        references,
+      }),
+    ).toEqual({
+      input: buildCodeReferencePrompt('Please review this change', references),
+      references,
+    });
+  });
+
+  it('returns null when there is no text or code reference context to send', () => {
+    expect(
+      buildHumanMessageInputPayload({
+        content: '   ',
+        references: [],
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/chatkit-ui/src/lib/code-references.ts
+++ b/packages/chatkit-ui/src/lib/code-references.ts
@@ -157,3 +157,34 @@ export function buildCodeReferencePrompt(
 
   return `${trimmedPrompt}\n\nReferenced code:\n${referenceBody}`;
 }
+
+export type HumanMessageInputPayloadSource = {
+  content?: string | null;
+  submittedInput?: string | null;
+  references?: ChatKitCodeReference[];
+};
+
+export function buildHumanMessageInputPayload(
+  source: HumanMessageInputPayloadSource,
+): { input: string; references?: ChatKitCodeReference[] } | null {
+  const references = normalizeCodeReferences(source.references);
+  const submittedInput =
+    typeof source.submittedInput === 'string' ? source.submittedInput.trim() : '';
+
+  if (submittedInput) {
+    return {
+      input: submittedInput,
+      ...(references.length > 0 ? { references } : {}),
+    };
+  }
+
+  const input = buildCodeReferencePrompt(source.content ?? '', references);
+  if (!input) {
+    return null;
+  }
+
+  return {
+    input,
+    ...(references.length > 0 ? { references } : {}),
+  };
+}

--- a/packages/chatkit-ui/src/lib/code-references.ts
+++ b/packages/chatkit-ui/src/lib/code-references.ts
@@ -1,0 +1,159 @@
+import type { Attachment, ChatKitCodeReference } from '@xpert-ai/chatkit-types';
+
+export type ComposerValuePayload = {
+  text?: string;
+  reply?: string;
+  attachments?: Attachment[];
+  references?: ChatKitCodeReference[];
+  appendReferences?: boolean;
+  selectedToolId?: string | null;
+  selectedModelId?: string | null;
+};
+
+type CodeReferenceCandidate = {
+  id?: unknown;
+  label?: unknown;
+  path?: unknown;
+  text?: unknown;
+  startLine?: unknown;
+  endLine?: unknown;
+  language?: unknown;
+  taskId?: unknown;
+};
+
+function isCodeReferenceCandidate(
+  value: unknown,
+): value is CodeReferenceCandidate {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function toLineNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+  return null;
+}
+
+export function normalizeCodeReferences(
+  value: unknown,
+): ChatKitCodeReference[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const normalized: ChatKitCodeReference[] = [];
+
+  value.forEach((item) => {
+    if (!isCodeReferenceCandidate(item)) {
+      return;
+    }
+
+    const id = toOptionalString(item.id);
+    const label = toOptionalString(item.label);
+    const path = toOptionalString(item.path);
+    const text = typeof item.text === 'string' ? item.text : '';
+    const startLine = toLineNumber(item.startLine);
+    const endLine = toLineNumber(item.endLine);
+    const language = toOptionalString(item.language);
+    const taskId = toOptionalString(item.taskId);
+
+    if (!path || !text || startLine === null || endLine === null) {
+      return;
+    }
+
+    normalized.push({
+      ...(id ? { id } : {}),
+      ...(label ? { label } : {}),
+      path,
+      startLine,
+      endLine,
+      text,
+      ...(language ? { language } : {}),
+      ...(taskId ? { taskId } : {}),
+    });
+  });
+
+  return normalized;
+}
+
+export function getCodeReferenceKey(reference: ChatKitCodeReference): string {
+  if (reference.id && reference.id.trim()) {
+    return reference.id.trim();
+  }
+  return [
+    reference.path,
+    reference.startLine,
+    reference.endLine,
+    reference.text,
+  ].join(':');
+}
+
+export function mergeCodeReferences(
+  current: ChatKitCodeReference[],
+  incoming: ChatKitCodeReference[],
+): ChatKitCodeReference[] {
+  const merged = [...current];
+  const seen = new Set(current.map(getCodeReferenceKey));
+
+  incoming.forEach((reference) => {
+    const key = getCodeReferenceKey(reference);
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    merged.push(reference);
+  });
+
+  return merged;
+}
+
+export function getCodeReferenceRange(reference: ChatKitCodeReference): string {
+  return reference.startLine === reference.endLine
+    ? `${reference.startLine}`
+    : `${reference.startLine}-${reference.endLine}`;
+}
+
+export function getCodeReferenceLabel(reference: ChatKitCodeReference): string {
+  if (reference.label && reference.label.trim()) {
+    return reference.label.trim();
+  }
+  const segments = reference.path.split('/');
+  const fileName = segments[segments.length - 1] || reference.path;
+  return `${fileName} ${getCodeReferenceRange(reference)}`;
+}
+
+function getCodeFenceLanguage(reference: ChatKitCodeReference): string {
+  return reference.language?.trim() ? reference.language.trim() : '';
+}
+
+function formatSingleCodeReference(reference: ChatKitCodeReference): string {
+  const location = `${reference.path}:${getCodeReferenceRange(reference)}`;
+  const fenceLanguage = getCodeFenceLanguage(reference);
+  return [
+    `[${location}]`,
+    `\`\`\`${fenceLanguage}`,
+    reference.text,
+    '```',
+  ].join('\n');
+}
+
+export function buildCodeReferencePrompt(
+  promptText: string,
+  references: ChatKitCodeReference[],
+): string {
+  const trimmedPrompt = promptText.trim();
+  if (references.length === 0) {
+    return trimmedPrompt;
+  }
+
+  const referenceBody = references.map(formatSingleCodeReference).join('\n\n');
+  if (!trimmedPrompt) {
+    return `Referenced code:\n${referenceBody}`;
+  }
+
+  return `${trimmedPrompt}\n\nReferenced code:\n${referenceBody}`;
+}

--- a/packages/chatkit-ui/src/providers/ParentMessenger.tsx
+++ b/packages/chatkit-ui/src/providers/ParentMessenger.tsx
@@ -1,44 +1,67 @@
-import { createContext, useCallback, useEffect, useMemo, useRef, type ReactNode } from "react";
-import { STATE_VARIABLE_HUMAN, type ChatKitOptions, type SendUserMessageParams } from "@xpert-ai/chatkit-types";
-import type { Capability } from "@xpert-ai/chatkit-web-shared";
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from 'react';
+import {
+  STATE_VARIABLE_HUMAN,
+  type ChatKitOptions,
+  type SendUserMessageParams,
+} from '@xpert-ai/chatkit-types';
+import type { Capability } from '@xpert-ai/chatkit-web-shared';
 import type { Message } from '@xpert-ai/xpert-sdk';
-import { useStreamManager } from "../hooks/useStream";
-import { createMessageId } from "../lib/utils";
-import { buildInjectedRequestOptions } from "../lib/request-options";
+import { useStreamManager } from '../hooks/useStream';
+import { createMessageId } from '../lib/utils';
+import { buildInjectedRequestOptions } from '../lib/request-options';
+import {
+  buildCodeReferencePrompt,
+  type ComposerValuePayload,
+  normalizeCodeReferences,
+} from '../lib/code-references';
 
 type CommandMessageMap = {
-  onSendUserMessage: SendUserMessageParams
+  onSendUserMessage: SendUserMessageParams;
+  onSetComposerValue: ComposerValuePayload | null;
   onSetOptions: ChatKitOptions | null;
+  onFocusComposer: null;
   onSetThreadId: { threadId: string | null };
   onClientToolCall: unknown;
   onGetClientSecret: string | null;
   onWidgetAction: {
     action: string;
     widgetItem: unknown;
-  }
-}
+  };
+};
 
-type ParentCommandMessage<K extends keyof CommandMessageMap = keyof CommandMessageMap> = {
-  type: "command";
+type ParentCommandMessage<
+  K extends keyof CommandMessageMap = keyof CommandMessageMap,
+> = {
+  type: 'command';
   nonce: string;
   command: K;
   data: CommandMessageMap[K];
 };
 
 type ParentResponseMessage = {
-  type: "response";
+  type: 'response';
   nonce: string;
   response?: unknown;
   error?: unknown;
 };
 
 type ParentEventMessage = {
-  type: "event";
+  type: 'event';
   event: 'public_event';
   data: [Capability.Event, unknown];
 };
 
-type ParentMessage = ParentCommandMessage | ParentResponseMessage | ParentEventMessage
+type ParentMessage =
+  | ParentCommandMessage
+  | ParentResponseMessage
+  | ParentEventMessage;
 
 type ParentEnvelope = Partial<ParentMessage> & { __xpaiChatKit: true };
 
@@ -46,16 +69,16 @@ const handledSendUserMessageNonces = new Set<string>();
 const handledSendUserMessageEvents = new WeakSet<MessageEvent>();
 
 const getParentOrigin = () => {
-  if (typeof document === "undefined" || !document.referrer) return "*";
+  if (typeof document === 'undefined' || !document.referrer) return '*';
   try {
     return new URL(document.referrer).origin;
   } catch {
-    return "*";
+    return '*';
   }
 };
 
 const createNonce = () => {
-  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
     return crypto.randomUUID();
   }
   return `ck_${Date.now()}_${Math.random().toString(16).slice(2)}`;
@@ -64,20 +87,33 @@ const createNonce = () => {
 export type ParentMessenger = {
   isParentAvailable: boolean;
   sendCommand: <C extends keyof CommandMessageMap>(
-      command: C,
-      data?: CommandMessageMap[C],
-      transfer?: Transferable[],
-    ) => Promise<unknown>;
-  sendEvent: (event: 'public_event', data?: [Capability.Event, unknown], transfer?: Transferable[]) => void;
+    command: C,
+    data?: CommandMessageMap[C],
+    transfer?: Transferable[],
+  ) => Promise<unknown>;
+  sendEvent: (
+    event: 'public_event',
+    data?: [Capability.Event, unknown],
+    transfer?: Transferable[],
+  ) => void;
 };
 
 type OnSetOptionsHandler = (options: ChatKitOptions | null) => void;
+type OnSetComposerValueHandler = (
+  payload: ComposerValuePayload | null,
+) => void | Promise<void>;
+type OnFocusComposerHandler = () => void | Promise<void>;
 
 type ParentMessengerContextValue = ParentMessenger & {
   registerOnSetOptions: (handler: OnSetOptionsHandler) => () => void;
+  registerOnSetComposerValue: (
+    handler: OnSetComposerValueHandler,
+  ) => () => void;
+  registerOnFocusComposer: (handler: OnFocusComposerHandler) => () => void;
 };
 
-export const ParentMessengerContext = createContext<ParentMessengerContextValue | null>(null);
+export const ParentMessengerContext =
+  createContext<ParentMessengerContextValue | null>(null);
 
 export type ParentMessengerProviderProps = {
   children: ReactNode;
@@ -87,7 +123,7 @@ export function ParentMessengerProvider({
   children,
 }: ParentMessengerProviderProps) {
   const { streamRef } = useStreamManager();
-  const parentOriginRef = useRef<string>("*");
+  const parentOriginRef = useRef<string>('*');
   const pendingRef = useRef(
     new Map<
       string,
@@ -95,10 +131,14 @@ export function ParentMessengerProvider({
     >(),
   );
   const onSetOptionsHandlersRef = useRef(new Set<OnSetOptionsHandler>());
+  const onSetComposerValueHandlersRef = useRef(
+    new Set<OnSetComposerValueHandler>(),
+  );
+  const onFocusComposerHandlersRef = useRef(new Set<OnFocusComposerHandler>());
   const latestOptionsRef = useRef<ChatKitOptions | null>(null);
 
   const isParentAvailable = useMemo(() => {
-    return typeof window !== "undefined" && window.parent !== window;
+    return typeof window !== 'undefined' && window.parent !== window;
   }, []);
 
   useEffect(() => {
@@ -112,13 +152,37 @@ export function ParentMessengerProvider({
     };
   }, []);
 
+  const registerOnSetComposerValue = useCallback(
+    (handler: OnSetComposerValueHandler) => {
+      onSetComposerValueHandlersRef.current.add(handler);
+      return () => {
+        onSetComposerValueHandlersRef.current.delete(handler);
+      };
+    },
+    [],
+  );
+
+  const registerOnFocusComposer = useCallback(
+    (handler: OnFocusComposerHandler) => {
+      onFocusComposerHandlersRef.current.add(handler);
+      return () => {
+        onFocusComposerHandlersRef.current.delete(handler);
+      };
+    },
+    [],
+  );
+
   useEffect(() => {
     if (!isParentAvailable) return;
 
-    const sendResponse = (nonce: string, response?: unknown, error?: unknown) => {
+    const sendResponse = (
+      nonce: string,
+      response?: unknown,
+      error?: unknown,
+    ) => {
       const message: ParentEnvelope = {
         __xpaiChatKit: true,
-        type: "response",
+        type: 'response',
         nonce,
         response,
         error,
@@ -128,10 +192,10 @@ export function ParentMessengerProvider({
 
     const handleMessage = (event: MessageEvent) => {
       if (event.source !== window.parent) return;
-      if (!event.data || typeof event.data !== "object") return;
+      if (!event.data || typeof event.data !== 'object') return;
       if (
-        parentOriginRef.current !== "*" &&
-        typeof event.origin === "string" &&
+        parentOriginRef.current !== '*' &&
+        typeof event.origin === 'string' &&
         event.origin !== parentOriginRef.current
       ) {
         return;
@@ -139,8 +203,11 @@ export function ParentMessengerProvider({
 
       const payload = event.data as Partial<ParentEnvelope>;
       if (payload.__xpaiChatKit !== true) return;
-      if (payload.type == "command" && payload.command === "onSendUserMessage") {
-        const nonce = typeof payload.nonce === "string" ? payload.nonce : null;
+      if (
+        payload.type == 'command' &&
+        payload.command === 'onSendUserMessage'
+      ) {
+        const nonce = typeof payload.nonce === 'string' ? payload.nonce : null;
         if (nonce) {
           if (handledSendUserMessageNonces.has(nonce)) return;
           handledSendUserMessageNonces.add(nonce);
@@ -149,36 +216,52 @@ export function ParentMessengerProvider({
           handledSendUserMessageEvents.add(event);
         }
 
-        const params = payload.data as SendUserMessageParams
-        const prompt = (params.text ?? params.state?.[STATE_VARIABLE_HUMAN]?.input ?? '').trim();
-        const newMessage: Message = {
-            id: createMessageId(),
-            type: 'human',
-            content: prompt,
-          };
+        const params = payload.data as SendUserMessageParams;
+        const prompt = (
+          params.text ??
+          params.state?.[STATE_VARIABLE_HUMAN]?.input ??
+          ''
+        ).trim();
+        const references = normalizeCodeReferences(
+          params.state?.[STATE_VARIABLE_HUMAN]?.references,
+        );
+        const submittedInput = buildCodeReferencePrompt(prompt, references);
+        const newMessage: Message & {
+          references?: ReturnType<typeof normalizeCodeReferences>;
+        } = {
+          id: createMessageId(),
+          type: 'human',
+          content: prompt || (references.length > 0 ? 'Referenced code' : ''),
+          ...(references.length > 0 ? { references } : {}),
+        };
         const requestOptions = buildInjectedRequestOptions({
           defaults: latestOptionsRef.current?.request,
           state: params.state,
           humanInput: {
-            input: prompt,
+            input: submittedInput,
+            ...(references.length > 0 ? { references } : {}),
           },
         });
 
-        streamRef.current?.submit({
+        streamRef.current?.submit(
+          {
             input: {
-              input: prompt,
+              input: submittedInput,
+              ...(references.length > 0 ? { references } : {}),
             },
             ...(requestOptions.state ? { state: requestOptions.state } : {}),
-          }
-          ,{
+          },
+          {
             newThread: params.newThread,
-            ...(requestOptions.context ? { context: requestOptions.context } : {}),
+            ...(requestOptions.context
+              ? { context: requestOptions.context }
+              : {}),
             ...(requestOptions.config ? { config: requestOptions.config } : {}),
             optimisticValues: (prev) => {
               const prevMessages = prev?.messages ?? [];
               return { ...prev, messages: [...prevMessages, newMessage] };
             },
-          }
+          },
         );
         if (payload.nonce) {
           sendResponse(payload.nonce, { ok: true });
@@ -186,9 +269,42 @@ export function ParentMessengerProvider({
         return;
       }
 
+      if (
+        payload.type == 'command' &&
+        payload.command === 'onSetComposerValue'
+      ) {
+        const nextPayload =
+          (payload.data as ComposerValuePayload | null) ?? null;
+        const normalizedPayload =
+          nextPayload && Array.isArray(nextPayload.references)
+            ? {
+                ...nextPayload,
+                references: normalizeCodeReferences(nextPayload.references),
+              }
+            : nextPayload;
+
+        void Promise.all(
+          [...onSetComposerValueHandlersRef.current].map((handler) =>
+            Promise.resolve(handler(normalizedPayload)),
+          ),
+        )
+          .then(() => {
+            if (payload.nonce) {
+              sendResponse(payload.nonce, { ok: true });
+            }
+          })
+          .catch((error) => {
+            if (payload.nonce) {
+              sendResponse(payload.nonce, undefined, error);
+            }
+          });
+        return;
+      }
+
       // Handle `setOptions` command
-      if (payload.type == "command" && payload.command === "onSetOptions") {
-        latestOptionsRef.current = (payload.data as ChatKitOptions | null) ?? null;
+      if (payload.type == 'command' && payload.command === 'onSetOptions') {
+        latestOptionsRef.current =
+          (payload.data as ChatKitOptions | null) ?? null;
         if (onSetOptionsHandlersRef.current.size > 0) {
           onSetOptionsHandlersRef.current.forEach((handler) => {
             handler(payload.data as ChatKitOptions | null);
@@ -200,8 +316,27 @@ export function ParentMessengerProvider({
         return;
       }
 
+      if (payload.type == 'command' && payload.command === 'onFocusComposer') {
+        void Promise.all(
+          [...onFocusComposerHandlersRef.current].map((handler) =>
+            Promise.resolve(handler()),
+          ),
+        )
+          .then(() => {
+            if (payload.nonce) {
+              sendResponse(payload.nonce, { ok: true });
+            }
+          })
+          .catch((error) => {
+            if (payload.nonce) {
+              sendResponse(payload.nonce, undefined, error);
+            }
+          });
+        return;
+      }
+
       // Handle `setThreadId` command
-      if (payload.type == "command" && payload.command === "onSetThreadId") {
+      if (payload.type == 'command' && payload.command === 'onSetThreadId') {
         const data = payload.data as
           | { threadId: string | null }
           | null
@@ -211,14 +346,14 @@ export function ParentMessengerProvider({
         stream?.reset(nextThreadId, undefined, { suppressThreadChange: true });
         if (stream && nextThreadId) {
           stream.loadThread(nextThreadId).catch((err) => {
-              console.warn('Failed to load thread messages', err);
-            });
+            console.warn('Failed to load thread messages', err);
+          });
         }
         return;
       }
 
-      if (payload.type !== "response") return
-      if (typeof payload.nonce !== "string") return;
+      if (payload.type !== 'response') return;
+      if (typeof payload.nonce !== 'string') return;
       const handler = pendingRef.current.get(payload.nonce);
       if (!handler) return;
 
@@ -230,26 +365,30 @@ export function ParentMessengerProvider({
       pendingRef.current.delete(payload.nonce);
     };
 
-    window.addEventListener("message", handleMessage);
+    window.addEventListener('message', handleMessage);
     return () => {
-      window.removeEventListener("message", handleMessage);
+      window.removeEventListener('message', handleMessage);
       pendingRef.current.forEach((handler) => {
-        handler.reject(new Error("Parent messenger closed"));
+        handler.reject(new Error('Parent messenger closed'));
       });
       pendingRef.current.clear();
     };
   }, [isParentAvailable, streamRef]);
 
   const sendCommand = useCallback(
-    <K extends keyof CommandMessageMap>(command: K, data?: CommandMessageMap[K], transfer?: Transferable[]) => {
+    <K extends keyof CommandMessageMap>(
+      command: K,
+      data?: CommandMessageMap[K],
+      transfer?: Transferable[],
+    ) => {
       if (!isParentAvailable) {
-        return Promise.reject(new Error("Parent window not available"));
+        return Promise.reject(new Error('Parent window not available'));
       }
 
       const nonce = createNonce();
       const message: ParentEnvelope = {
         __xpaiChatKit: true,
-        type: "command",
+        type: 'command',
         nonce,
         command,
         data: data ?? null,
@@ -264,7 +403,11 @@ export function ParentMessengerProvider({
   );
 
   const sendEvent = useCallback(
-    (event: 'public_event', data?: [Capability.Event, unknown], transfer?: Transferable[]) => {
+    (
+      event: 'public_event',
+      data?: [Capability.Event, unknown],
+      transfer?: Transferable[],
+    ) => {
       if (!isParentAvailable) return;
       const message: ParentEnvelope = {
         __xpaiChatKit: true,
@@ -283,8 +426,17 @@ export function ParentMessengerProvider({
       sendCommand,
       sendEvent,
       registerOnSetOptions,
+      registerOnSetComposerValue,
+      registerOnFocusComposer,
     }),
-    [isParentAvailable, sendCommand, sendEvent, registerOnSetOptions],
+    [
+      isParentAvailable,
+      sendCommand,
+      sendEvent,
+      registerOnSetOptions,
+      registerOnSetComposerValue,
+      registerOnFocusComposer,
+    ],
   );
 
   return (

--- a/packages/chatkit-ui/src/providers/ParentMessenger.tsx
+++ b/packages/chatkit-ui/src/providers/ParentMessenger.tsx
@@ -228,10 +228,12 @@ export function ParentMessengerProvider({
         const submittedInput = buildCodeReferencePrompt(prompt, references);
         const newMessage: Message & {
           references?: ReturnType<typeof normalizeCodeReferences>;
+          submittedInput?: string;
         } = {
           id: createMessageId(),
           type: 'human',
           content: prompt || (references.length > 0 ? 'Referenced code' : ''),
+          submittedInput,
           ...(references.length > 0 ? { references } : {}),
         };
         const requestOptions = buildInjectedRequestOptions({

--- a/packages/chatkit-ui/src/providers/Stream.tsx
+++ b/packages/chatkit-ui/src/providers/Stream.tsx
@@ -57,6 +57,7 @@ import { normalizeCodeReferences } from '../lib/code-references';
 type ChatKitAIMessage = Message & {
   executionId?: string;
   references?: ChatKitCodeReference[];
+  submittedInput?: string;
 };
 
 export type StateType = { messages: ChatKitAIMessage[] };
@@ -258,10 +259,15 @@ function extractCodeReferences(
 
 function mapChatMessageToUiMessage(message: ChatMessage): ChatKitAIMessage {
   const references = extractCodeReferences(message);
+  const content = message.content ?? '';
+  const type = normalizeRoleToMessageType(message.role);
   return {
     id: message.id ?? createMessageId(),
-    type: normalizeRoleToMessageType(message.role),
-    content: message.content ?? '',
+    type,
+    content,
+    ...(type === 'human' && typeof content === 'string'
+      ? { submittedInput: content }
+      : {}),
     ...(references ? { references } : {}),
     ...(message.reasoning ? { reasoning: message.reasoning as any } : {}),
     ...(message.executionId ? { executionId: message.executionId } : {}),

--- a/packages/chatkit-ui/src/providers/Stream.tsx
+++ b/packages/chatkit-ui/src/providers/Stream.tsx
@@ -18,7 +18,20 @@ import {
 } from '@xpert-ai/xpert-sdk';
 import type { Message } from '@langchain/core/messages';
 import { type ToolCall } from '@langchain/core/messages/tool';
-import { ChatMessageEventTypeEnum, ChatMessageTypeEnum, type ClientToolMessageInput, type ClientToolRequest, type ClientToolResponse, type TChatRequest, type TMessageContent, type ChatEventEnvelope, type TMessageContentComplex, type TMessageContentComponent, type TThreadContextUsageEvent } from '@xpert-ai/chatkit-types';
+import {
+  ChatMessageEventTypeEnum,
+  ChatMessageTypeEnum,
+  type ChatKitCodeReference,
+  type ClientToolMessageInput,
+  type ClientToolRequest,
+  type ClientToolResponse,
+  type TChatRequest,
+  type TMessageContent,
+  type ChatEventEnvelope,
+  type TMessageContentComplex,
+  type TMessageContentComponent,
+  type TThreadContextUsageEvent,
+} from '@xpert-ai/chatkit-types';
 import { appendMessageContent } from '../lib/message';
 import {
   normalizeClientSecretResult,
@@ -39,8 +52,12 @@ import {
   parseThreadContextUsageEvent,
   type ThreadContextUsageByAgentKey,
 } from '../lib/thread-context-usage';
+import { normalizeCodeReferences } from '../lib/code-references';
 
-type ChatKitAIMessage = Message & { executionId?: string };
+type ChatKitAIMessage = Message & {
+  executionId?: string;
+  references?: ChatKitCodeReference[];
+};
 
 export type StateType = { messages: ChatKitAIMessage[] };
 
@@ -155,11 +172,10 @@ export function createFetchWithClientSecretRefresh({
 
 function applyOptimisticValues(
   prev: StateType,
-  optimistic:
-    | Partial<StateType>
-    | ((prev: StateType) => Partial<StateType>),
+  optimistic: Partial<StateType> | ((prev: StateType) => Partial<StateType>),
 ): StateType {
-  const update = typeof optimistic === 'function' ? optimistic(prev) : optimistic;
+  const update =
+    typeof optimistic === 'function' ? optimistic(prev) : optimistic;
   return { ...prev, ...update };
 }
 
@@ -186,12 +202,67 @@ function normalizeRoleToMessageType(role?: string): Message['type'] {
   return 'ai';
 }
 
+type ReferencePayloadContainer = {
+  references?: unknown;
+  input?: unknown;
+  metadata?: unknown;
+  state?: unknown;
+};
+
+type ReferenceStateContainer = {
+  human?: unknown;
+};
+
+function isReferencePayloadContainer(
+  value: unknown,
+): value is ReferencePayloadContainer {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getNestedReferenceCandidate(value: unknown): unknown {
+  return isReferencePayloadContainer(value) ? value.references : undefined;
+}
+
+function extractCodeReferences(
+  value: unknown,
+): ChatKitCodeReference[] | undefined {
+  const direct = normalizeCodeReferences(value);
+  if (direct.length > 0) {
+    return direct;
+  }
+
+  if (!isReferencePayloadContainer(value)) {
+    return undefined;
+  }
+
+  const state = isReferencePayloadContainer(value.state)
+    ? (value.state as ReferenceStateContainer)
+    : null;
+
+  const candidates = [
+    value.references,
+    getNestedReferenceCandidate(value.input),
+    getNestedReferenceCandidate(value.metadata),
+    getNestedReferenceCandidate(state?.human),
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeCodeReferences(candidate);
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+
+  return undefined;
+}
 
 function mapChatMessageToUiMessage(message: ChatMessage): ChatKitAIMessage {
+  const references = extractCodeReferences(message);
   return {
     id: message.id ?? createMessageId(),
     type: normalizeRoleToMessageType(message.role),
     content: message.content ?? '',
+    ...(references ? { references } : {}),
     ...(message.reasoning ? { reasoning: message.reasoning as any } : {}),
     ...(message.executionId ? { executionId: message.executionId } : {}),
   } as ChatKitAIMessage;
@@ -208,7 +279,9 @@ function sortMessagesByCreatedAt(items: ChatMessage[]): ChatMessage[] {
   });
 }
 
-function normalizeMessageType(value: unknown): ChatKitAIMessage['type'] | undefined {
+function normalizeMessageType(
+  value: unknown,
+): ChatKitAIMessage['type'] | undefined {
   if (typeof value !== 'string') return undefined;
   const normalized = value.toLowerCase();
   switch (normalized) {
@@ -318,9 +391,7 @@ function createMessageFromData(data: unknown): ChatKitAIMessage | null {
   const content =
     'text' in raw ? (raw as { text?: Message['content'] }).text : data;
   const type =
-    normalizeMessageType(raw.type) ??
-    normalizeMessageType(raw.role) ??
-    'ai';
+    normalizeMessageType(raw.type) ?? normalizeMessageType(raw.role) ?? 'ai';
   const id = typeof raw.id === 'string' ? raw.id : createMessageId();
   const executionId =
     typeof raw.executionId === 'string' ? raw.executionId : undefined;
@@ -361,7 +432,9 @@ function updateLatestMessage(
     const messages = prev.messages ?? [];
     if (messages.length === 0) return prev;
     const nextMessages = [...messages];
-    nextMessages[messages.length - 1] = updater(nextMessages[messages.length - 1]);
+    nextMessages[messages.length - 1] = updater(
+      nextMessages[messages.length - 1],
+    );
     return { ...prev, messages: nextMessages };
   });
 }
@@ -393,23 +466,28 @@ function applyMessageData(
  */
 function appendMessageComponent(
   setValues: React.Dispatch<React.SetStateAction<StateType>>,
-  content: TMessageContentComplex) {
+  content: TMessageContentComplex,
+) {
   updateLatestMessage(setValues, (lastM) => {
-      // Deep clone the message to avoid mutation issues with React Strict Mode
-      // React Strict Mode calls state updater twice, and appendMessageContent mutates the content array
-      const lastMessage = lastM as unknown as Record<string, unknown>
-      const clonedMessage = {
-        ...lastMessage,
-        content: Array.isArray(lastMessage.content)
-          ? (lastMessage.content as Record<string, unknown>[]).map((item) => ({ ...item }))
-          : lastMessage.content,
-        reasoning: Array.isArray(lastMessage.reasoning)
-          ? (lastMessage.reasoning as Record<string, unknown>[]).map((r) => ({ ...r }))
-          : lastMessage.reasoning
-      }
-      appendMessageContent(clonedMessage as any, content)
-      return clonedMessage as unknown as Message
-    })
+    // Deep clone the message to avoid mutation issues with React Strict Mode
+    // React Strict Mode calls state updater twice, and appendMessageContent mutates the content array
+    const lastMessage = lastM as unknown as Record<string, unknown>;
+    const clonedMessage = {
+      ...lastMessage,
+      content: Array.isArray(lastMessage.content)
+        ? (lastMessage.content as Record<string, unknown>[]).map((item) => ({
+            ...item,
+          }))
+        : lastMessage.content,
+      reasoning: Array.isArray(lastMessage.reasoning)
+        ? (lastMessage.reasoning as Record<string, unknown>[]).map((r) => ({
+            ...r,
+          }))
+        : lastMessage.reasoning,
+    };
+    appendMessageContent(clonedMessage as any, content);
+    return clonedMessage as unknown as Message;
+  });
 }
 
 function normalizeClientToolRequest(value: unknown): ClientToolRequest | null {
@@ -449,7 +527,9 @@ function collectClientToolRequests(payload: unknown): ClientToolRequest[] {
   return requests;
 }
 
-function normalizeToolMessagesResponse(response: unknown): ClientToolMessageInput | null {
+function normalizeToolMessagesResponse(
+  response: unknown,
+): ClientToolMessageInput | null {
   if (!response) return null;
   if (typeof response === 'object' && response !== null) {
     const raw = response as ClientToolMessageInput;
@@ -458,9 +538,9 @@ function normalizeToolMessagesResponse(response: unknown): ClientToolMessageInpu
       name: raw.name,
       content: raw.content,
       status: raw.status,
-    }
+    };
   }
-  return null
+  return null;
 }
 
 /**
@@ -510,9 +590,9 @@ export function applyStreamEvent(
 
   if (typeof parsed !== 'object' || parsed == null) return;
 
-  const payload = parsed as ChatEventEnvelope<TMessageContentComponent<any>>
+  const payload = parsed as ChatEventEnvelope<TMessageContentComponent<any>>;
 
-  const payloadType: ChatMessageTypeEnum = payload.type
+  const payloadType: ChatMessageTypeEnum = payload.type;
 
   if (payloadType === ChatMessageTypeEnum.MESSAGE) {
     if (typeof payload.data === 'string') {
@@ -520,17 +600,18 @@ export function applyStreamEvent(
       return;
     }
 
-    const message = payload.data
+    const message = payload.data;
     if (message.type === 'component') {
-      sendEvent('public_event', ['log', {...message, name: 'component'}]);
+      sendEvent('public_event', ['log', { ...message, name: 'component' }]);
     }
     appendMessageComponent(setValues, message);
     return;
   }
 
   if (payloadType === ChatMessageTypeEnum.EVENT) {
-    const eventType =
-      (typeof payload.event === 'string' ? payload.event.toLowerCase() : '') as ChatMessageEventTypeEnum;
+    const eventType = (
+      typeof payload.event === 'string' ? payload.event.toLowerCase() : ''
+    ) as ChatMessageEventTypeEnum;
     const meta = extractMessageMeta(payload.data);
     const executionId = extractExecutionId(payload.data);
 
@@ -548,9 +629,14 @@ export function applyStreamEvent(
     switch (eventType) {
       case ChatMessageEventTypeEnum.ON_CONVERSATION_START:
       case ChatMessageEventTypeEnum.ON_CONVERSATION_END: {
-        const eventData = payload.data as { messages?: ChatKitAIMessage[] } | null;
+        const eventData = payload.data as {
+          messages?: ChatKitAIMessage[];
+        } | null;
         if (eventData && Array.isArray(eventData.messages)) {
-          setValues((prev) => ({ ...prev, messages: eventData.messages ?? [] }));
+          setValues((prev) => ({
+            ...prev,
+            messages: eventData.messages ?? [],
+          }));
         }
         break;
       }
@@ -576,17 +662,15 @@ export function applyStreamEvent(
               if (
                 meta.content !== undefined &&
                 (last.content == null ||
-                  (typeof last.content === 'string' && last.content.length === 0))
+                  (typeof last.content === 'string' &&
+                    last.content.length === 0))
               ) {
                 nextLast.content = meta.content;
               }
               nextMessages[messages.length - 1] = nextLast;
               return { ...prev, messages: nextMessages };
             }
-            if (
-              typeof last.content === 'string' &&
-              last.content.length === 0
-            ) {
+            if (typeof last.content === 'string' && last.content.length === 0) {
               const nextMessages = [...messages];
               nextMessages[messages.length - 1] = message;
               return { ...prev, messages: nextMessages };
@@ -619,8 +703,11 @@ export function applyStreamEvent(
       }
       case ChatMessageEventTypeEnum.ON_CLIENT_EFFECT: {
         const toolCall = payload.data as unknown as ToolCall;
-        sendEvent('public_event', ['effect', {name: toolCall.name, data: toolCall.args}]);
-        break
+        sendEvent('public_event', [
+          'effect',
+          { name: toolCall.name, data: toolCall.args },
+        ]);
+        break;
       }
       case ChatMessageEventTypeEnum.ON_CHAT_EVENT: {
         const contextUsageEvent = parseThreadContextUsageEvent(payload.data);
@@ -673,11 +760,13 @@ const StreamSession = ({
   const submitRef = useRef<StreamContextType['submit'] | null>(null);
   const runtimeClientSecretRef = useRef(apiKey);
   const runtimeOrganizationIdRef = useRef<string | undefined>(organizationId);
-  const refreshClientSecretPromiseRef = useRef<
-    Promise<ResolvedClientSecret> | null
-  >(null);
+  const refreshClientSecretPromiseRef =
+    useRef<Promise<ResolvedClientSecret> | null>(null);
   const lastStreamOptionsRef = useRef<
-    Pick<StreamSubmitOptions, 'streamMode' | 'streamSubgraphs' | 'streamResumable'>
+    Pick<
+      StreamSubmitOptions,
+      'streamMode' | 'streamSubgraphs' | 'streamResumable'
+    >
   >({});
   const lastExecutionIdRef = useRef<string | null>(null);
   const lastEventIdRef = useRef<string | null>(null);
@@ -703,7 +792,10 @@ const StreamSession = ({
       suppressThreadChangeRef.current = false;
       return;
     }
-    sendEvent('public_event', ['thread.change', { threadId: threadId ?? null }]);
+    sendEvent('public_event', [
+      'thread.change',
+      { threadId: threadId ?? null },
+    ]);
   }, [threadId, isParentAvailable, sendEvent]);
 
   useEffect(() => {
@@ -715,10 +807,12 @@ const StreamSession = ({
     }
   }, [threadId]);
 
-  const refreshClientSecret = useCallback(
-    async (): Promise<ResolvedClientSecret> => {
+  const refreshClientSecret =
+    useCallback(async (): Promise<ResolvedClientSecret> => {
       if (!isParentAvailable) {
-        throw new Error('[chatkit-ui] Parent window is not available for client secret refresh.');
+        throw new Error(
+          '[chatkit-ui] Parent window is not available for client secret refresh.',
+        );
       }
       if (refreshClientSecretPromiseRef.current) {
         return refreshClientSecretPromiseRef.current;
@@ -726,7 +820,10 @@ const StreamSession = ({
 
       const refreshPromise = (async () => {
         const currentSecret = runtimeClientSecretRef.current.trim();
-        const response = await sendCommand('onGetClientSecret', currentSecret || null);
+        const response = await sendCommand(
+          'onGetClientSecret',
+          currentSecret || null,
+        );
         const nextClientSecret = normalizeClientSecretResult(
           response,
           runtimeOrganizationIdRef.current,
@@ -747,16 +844,15 @@ const StreamSession = ({
           refreshClientSecretPromiseRef.current = null;
         }
       }
-    },
-    [isParentAvailable, sendCommand],
-  );
+    }, [isParentAvailable, sendCommand]);
 
   const fetchWithClientSecretRefresh = useMemo(
     () =>
       createFetchWithClientSecretRefresh({
         getCurrentClientSecret: () => {
           const currentSecret = runtimeClientSecretRef.current.trim();
-          const currentOrganizationId = runtimeOrganizationIdRef.current?.trim();
+          const currentOrganizationId =
+            runtimeOrganizationIdRef.current?.trim();
 
           return currentOrganizationId
             ? { secret: currentSecret, organizationId: currentOrganizationId }
@@ -764,7 +860,10 @@ const StreamSession = ({
         },
         refreshClientSecret,
         onRefreshError: (refreshError) => {
-          console.warn('[chatkit-ui] Failed to refresh client secret:', refreshError);
+          console.warn(
+            '[chatkit-ui] Failed to refresh client secret:',
+            refreshError,
+          );
         },
       }),
     [refreshClientSecret],
@@ -836,26 +935,29 @@ const StreamSession = ({
     [apiUrl, client, runtimeClientSecret, stop],
   );
 
-  const reset = useCallback((
-    newThreadId?: string | null,
-    initialMessages?: ChatKitAIMessage[],
-    options?: { suppressThreadChange?: boolean },
-  ) => {
-    abortRef.current?.abort();
-    abortRef.current = null;
-    setIsLoading(false);
-    setError(null);
-    setContextUsageByAgentKey({});
-    setValues({ messages: initialMessages ?? [] });
-    lastExecutionIdRef.current = null;
-    lastEventIdRef.current = null;
-    if (newThreadId !== undefined) {
-      if (options?.suppressThreadChange && newThreadId !== threadId) {
-        suppressThreadChangeRef.current = true;
+  const reset = useCallback(
+    (
+      newThreadId?: string | null,
+      initialMessages?: ChatKitAIMessage[],
+      options?: { suppressThreadChange?: boolean },
+    ) => {
+      abortRef.current?.abort();
+      abortRef.current = null;
+      setIsLoading(false);
+      setError(null);
+      setContextUsageByAgentKey({});
+      setValues({ messages: initialMessages ?? [] });
+      lastExecutionIdRef.current = null;
+      lastEventIdRef.current = null;
+      if (newThreadId !== undefined) {
+        if (options?.suppressThreadChange && newThreadId !== threadId) {
+          suppressThreadChangeRef.current = true;
+        }
+        setThreadId(newThreadId);
       }
-      setThreadId(newThreadId);
-    }
-  }, [setThreadId, threadId]);
+    },
+    [setThreadId, threadId],
+  );
 
   const handleInterrupt = useCallback(
     async (data: unknown) => {
@@ -887,14 +989,15 @@ const StreamSession = ({
       }
 
       if (toolMessages.length > 0) {
-        await submitRef.current?.({
+        await submitRef.current?.(
+          {
             input: {},
             command: {
               resume: {
-                  toolMessages: toolMessages,
-              } as ClientToolResponse
+                toolMessages: toolMessages,
+              } as ClientToolResponse,
             },
-            executionId: lastExecutionIdRef.current ?? undefined
+            executionId: lastExecutionIdRef.current ?? undefined,
           },
           lastStreamOptionsRef.current,
         );
@@ -902,82 +1005,92 @@ const StreamSession = ({
     },
     [isParentAvailable, sendCommand, setError],
   );
-  
-  const runStream = useCallback(async (
-    nextThreadId: string,
-    input?: TChatRequest | null,
-    options?: StreamSubmitOptions,
-    runId?: string,
-  ) => {
-    const abortController = new AbortController();
-    abortRef.current?.abort();
-    abortRef.current = abortController;
-    setIsLoading(true);
-    try {
-      const normalizedRequest = normalizeRequestContextAndConfig({
-        context: options?.context,
-        config: options?.config,
-      });
-      const stream = options?.joinExistingThread && runId ? client.runs.joinStream(nextThreadId, runId) :
-        client.runs.stream(nextThreadId, assistantId, {
-          input: input ?? null,
-          context: normalizedRequest.context,
-          config: normalizedRequest.config as Config | undefined,
-          checkpoint: options?.checkpoint ?? undefined,
-          streamMode: options?.streamMode,
-          streamSubgraphs: options?.streamSubgraphs,
-          streamResumable: options?.streamResumable,
-          signal: abortController.signal,
-          onDisconnect: 'continue'
+
+  const runStream = useCallback(
+    async (
+      nextThreadId: string,
+      input?: TChatRequest | null,
+      options?: StreamSubmitOptions,
+      runId?: string,
+    ) => {
+      const abortController = new AbortController();
+      abortRef.current?.abort();
+      abortRef.current = abortController;
+      setIsLoading(true);
+      try {
+        const normalizedRequest = normalizeRequestContextAndConfig({
+          context: options?.context,
+          config: options?.config,
         });
+        const stream =
+          options?.joinExistingThread && runId
+            ? client.runs.joinStream(nextThreadId, runId)
+            : client.runs.stream(nextThreadId, assistantId, {
+                input: input ?? null,
+                context: normalizedRequest.context,
+                config: normalizedRequest.config as Config | undefined,
+                checkpoint: options?.checkpoint ?? undefined,
+                streamMode: options?.streamMode,
+                streamSubgraphs: options?.streamSubgraphs,
+                streamResumable: options?.streamResumable,
+                signal: abortController.signal,
+                onDisconnect: 'continue',
+              });
 
-      const interrupts: unknown[] = [];
-      const langGraphEventState = createLangGraphEventState();
-      const eventContext: LangGraphEventContext = {
-        threadId: nextThreadId,
-        input,
-      };
-      for await (const chunk of stream) {
-        if (chunk?.id) {
-          lastEventIdRef.current = String(chunk.id);
+        const interrupts: unknown[] = [];
+        const langGraphEventState = createLangGraphEventState();
+        const eventContext: LangGraphEventContext = {
+          threadId: nextThreadId,
+          input,
+        };
+        for await (const chunk of stream) {
+          if (chunk?.id) {
+            lastEventIdRef.current = String(chunk.id);
+          }
+          applyStreamEvent(
+            chunk as StreamChunk,
+            setValues,
+            setError,
+            sendEvent,
+            interrupts,
+            langGraphEventState,
+            eventContext,
+            (executionId) => {
+              if (executionId) {
+                lastExecutionIdRef.current = executionId;
+              }
+            },
+            (event) => {
+              setContextUsageByAgentKey((prev) =>
+                applyThreadContextUsageEvent(prev, event, nextThreadId),
+              );
+            },
+          );
         }
-        applyStreamEvent(
-          chunk as StreamChunk,
-          setValues,
-          setError,
-          sendEvent,
-          interrupts,
-          langGraphEventState,
-          eventContext,
-          (executionId) => {
-            if (executionId) {
-              lastExecutionIdRef.current = executionId;
-            }
-          },
-          (event) => {
-            setContextUsageByAgentKey((prev) =>
-              applyThreadContextUsageEvent(prev, event, nextThreadId),
-            );
-          },
-        );
-      }
 
-      if (interrupts.length > 0) {
-        for await (const interruptData of interrupts) {
-          await handleInterrupt(interruptData);
+        if (interrupts.length > 0) {
+          for await (const interruptData of interrupts) {
+            await handleInterrupt(interruptData);
+          }
         }
+      } catch (streamError) {
+        if (
+          !(
+            streamError instanceof DOMException &&
+            streamError.name === 'AbortError'
+          )
+        ) {
+          setError(streamError);
+        }
+      } finally {
+        if (abortRef.current === abortController) {
+          abortRef.current = null;
+        }
+        setIsLoading(false);
       }
-    } catch (streamError) {
-      if (!(streamError instanceof DOMException && streamError.name === 'AbortError')) {
-        setError(streamError);
-      }
-    } finally {
-      if (abortRef.current === abortController) {
-        abortRef.current = null;
-      }
-      setIsLoading(false);
-    }
-  }, [assistantId, client, sendEvent, handleInterrupt]);
+    },
+    [assistantId, client, sendEvent, handleInterrupt],
+  );
 
   const loadThread = useCallback(
     async (threadId: string) => {
@@ -1007,7 +1120,8 @@ const StreamSession = ({
       await loadConversationMessages(conversation.id);
 
       const status = String(conversation.status ?? '').toLowerCase();
-      const shouldJoinStream = !status || status === 'running' || status === 'busy';
+      const shouldJoinStream =
+        !status || status === 'running' || status === 'busy';
       if (!shouldJoinStream) return;
 
       const lastAiMessageResult = await client.conversations.searchMessages(
@@ -1022,16 +1136,13 @@ const StreamSession = ({
       if (!runId) return;
       lastExecutionIdRef.current = runId;
 
-      await runStream(threadId, null, {joinExistingThread: true}, runId);
+      await runStream(threadId, null, { joinExistingThread: true }, runId);
     },
     [client, runStream, stop, loadConversationMessages, setThreadId],
   );
 
   const submit = useCallback(
-    async (
-      input?: TChatRequest | null,
-      options?: StreamSubmitOptions,
-    ) => {
+    async (input?: TChatRequest | null, options?: StreamSubmitOptions) => {
       // if (isLoading) {
       //   return;
       // }
@@ -1088,7 +1199,9 @@ const StreamSession = ({
   submitRef.current = submit;
 
   // isReady is true when we have a valid client secret (starts with 'cs-x-')
-  const isReady = Boolean(runtimeClientSecret && runtimeClientSecret.startsWith('cs-x-'));
+  const isReady = Boolean(
+    runtimeClientSecret && runtimeClientSecret.startsWith('cs-x-'),
+  );
 
   const value: StreamContextType = {
     client,

--- a/packages/chatkit/src/chatkit.ts
+++ b/packages/chatkit/src/chatkit.ts
@@ -1,4 +1,5 @@
-import type { ChatKitOptions } from "./options";
+import type { ChatKitCodeReference } from './message';
+import type { ChatKitOptions } from './options';
 
 export type EventHandler<K extends keyof ChatKitEvents> = (
   event: ChatKitEvents[K],
@@ -10,7 +11,7 @@ export type SendUserMessageParams = {
   reply?: string;
   attachments?: Attachment[];
   newThread?: boolean;
-}
+};
 
 /**
  * strategies to host files before attaching them to messages.
@@ -93,9 +94,13 @@ export interface XpertAIChatKit extends HTMLElement {
 
   /** Sets the composer's content without sending a message. */
   setComposerValue(params: {
-    text: string;
+    text?: string;
     reply?: string;
     attachments?: Attachment[];
+    references?: ChatKitCodeReference[];
+    appendReferences?: boolean;
+    selectedToolId?: string | null;
+    selectedModelId?: string | null;
   }): Promise<void>;
 
   /**

--- a/packages/chatkit/src/message.ts
+++ b/packages/chatkit/src/message.ts
@@ -1,10 +1,10 @@
-import type { ToolCall } from "@langchain/core/messages/tool";
+import type { ToolCall } from '@langchain/core/messages/tool';
 import { Types } from '@a2ui/lit/0.8';
 
 export enum ChatMessageTypeEnum {
   // LOG = 'log',
   MESSAGE = 'message',
-  EVENT = 'event'
+  EVENT = 'event',
 }
 
 /**
@@ -38,10 +38,10 @@ export enum ChatMessageEventTypeEnum {
  * Encapsulate multi-agent message events
  */
 export interface ChatEventEnvelope<T = unknown> {
-  type: ChatMessageTypeEnum
-  event?: ChatMessageEventTypeEnum
-  tags: string[]
-	data: T
+  type: ChatMessageTypeEnum;
+  event?: ChatMessageEventTypeEnum;
+  tags: string[];
+  data: T;
 }
 
 /**
@@ -80,229 +80,253 @@ export enum ChatMessageStepCategory {
   /**
    * Knowledges (knowledge base retriever results)
    */
-  Knowledges = 'knowledges'
+  Knowledges = 'knowledges',
 }
 
 /**
  * Step message type, in canvas and ai message.
  */
-export type TChatMessageStep<T = any> = TMessageComponent<TMessageComponentStep<T>>
+export type TChatMessageStep<T = any> = TMessageComponent<
+  TMessageComponentStep<T>
+>;
 
-export type ImageDetail = "auto" | "low" | "high";
+export type ImageDetail = 'auto' | 'low' | 'high';
 export type MessageContentText = {
-    type: "text";
-    text: string;
+  type: 'text';
+  text: string;
 };
 export type MessageContentImageUrl = {
-    type: "image_url";
-    image_url: string | {
+  type: 'image_url';
+  image_url:
+    | string
+    | {
         url: string;
         detail?: ImageDetail;
-    };
+      };
 };
 
 /**
  * Similar to {@link MessageContentText} | {@link MessageContentImageUrl}, which together form {@link MessageContentComplex}
  */
 export type TMessageContentComponent<T extends object = object> = {
-  id: string
-  type: 'component'
-  data: TMessageComponent<T>
-  xpertName?: string
+  id: string;
+  type: 'component';
+  data: TMessageComponent<T>;
+  xpertName?: string;
   agentKey?: string;
-}
+};
 
 /**
  * Defines the data type of the sub-message of `component` type in the message `content` {@link MessageContentComplex}
  */
 export type TMessageComponent<T extends object = object> = T & {
-  id?: string
-  category: 'Dashboard' | 'Computer' | 'Tool'
-  type?: string
-  created_date?: Date | string
-}
+  id?: string;
+  category: 'Dashboard' | 'Computer' | 'Tool';
+  type?: string;
+  created_date?: Date | string;
+};
 
 export type TMessageComponentWidgetItem = {
-  name: string
-  config: Types.Surface
-  values?: Record<string, unknown>
-}
+  name: string;
+  config: Types.Surface;
+  values?: Record<string, unknown>;
+};
 
 export type TMessageComponentWidgetData = {
-  type: 'Widget'
-  mode?: string
-  widgets: TMessageComponentWidgetItem[]
-  executionId?: string
-}
+  type: 'Widget';
+  mode?: string;
+  widgets: TMessageComponentWidgetItem[];
+  executionId?: string;
+};
 
-export type TMessageComponentWidget = TMessageComponent<TMessageComponentWidgetData>
+export type TMessageComponentWidget =
+  TMessageComponent<TMessageComponentWidgetData>;
 
-export type TMessageContentWidget = TMessageContentComponent<TMessageComponentWidgetData>
+export type TMessageContentWidget =
+  TMessageContentComponent<TMessageComponentWidgetData>;
 
 export type TMessageContentText = {
-  id?: string
-  xpertName?: string
-  agentKey?: string
-  type: "text";
+  id?: string;
+  xpertName?: string;
+  agentKey?: string;
+  type: 'text';
   text: string;
 };
 export type TMessageContentMemory = {
-  id?: string
-  agentKey?: string
-  type: "memory";
+  id?: string;
+  agentKey?: string;
+  type: 'memory';
   data: any[];
 };
 export type TMessageContentReasoning = {
-  id?: string
-  xpertName?: string
-  agentKey?: string
-  type: "reasoning";
+  id?: string;
+  xpertName?: string;
+  agentKey?: string;
+  type: 'reasoning';
   text: string;
 };
 /**
  * Enhance {@link MessageContentComplex} in Langchain.js
  */
-export type TMessageContentComplex = (TMessageContentText | TMessageContentReasoning | MessageContentImageUrl | TMessageContentComponent | TMessageContentMemory | (Record<string, any> & {
-  type?: "text" | "image_url" | string;
-}) | (Record<string, any> & {
-  type?: never;
-})) & {
-  id?: string
-  xpertName?: string
+export type TMessageContentComplex = (
+  | TMessageContentText
+  | TMessageContentReasoning
+  | MessageContentImageUrl
+  | TMessageContentComponent
+  | TMessageContentMemory
+  | (Record<string, any> & {
+      type?: 'text' | 'image_url' | string;
+    })
+  | (Record<string, any> & {
+      type?: never;
+    })
+) & {
+  id?: string;
+  xpertName?: string;
   agentKey?: string;
-  created_date?: Date | string
-}
+  created_date?: Date | string;
+};
 
 /**
  * Enhance {@link MessageContent} in Langchain.js
- * 
+ *
  * @deprecated use {@link TMessageItems} instead
  */
 export type TMessageContent = string | TMessageContentComplex[];
 
 export type TMessageComponentIframe = {
-  type: 'iframe'
-  title: string
-  url?: string
+  type: 'iframe';
+  title: string;
+  url?: string;
   data?: {
-    url?: string
-  }
-}
+    url?: string;
+  };
+};
 
 export type TMessageComponentStep<T = unknown> = {
-  type: ChatMessageStepCategory
-  toolset: string
-  toolset_id: string
-  tool?: string
-  title: string
-  message: string
-  status: 'success' | 'fail' | 'running'
-  created_date: Date | string
-  end_date: Date | string
-  error?: string
-  data?: T
-  input?: any
-  output?: string
-  artifact?: any
-}
+  type: ChatMessageStepCategory;
+  toolset: string;
+  toolset_id: string;
+  tool?: string;
+  title: string;
+  message: string;
+  status: 'success' | 'fail' | 'running';
+  created_date: Date | string;
+  end_date: Date | string;
+  error?: string;
+  data?: T;
+  input?: any;
+  output?: string;
+  artifact?: any;
+};
 
 /**
  * Data type for chat event message
  */
 export type TChatEventMessage = {
-  type?: string
-  title?: string
-  message?: string
-  status?: 'success' | 'fail' | 'running'
-  created_date?: Date | string
-  end_date?: Date | string
-  error?: string
-}
+  type?: string;
+  title?: string;
+  message?: string;
+  status?: 'success' | 'fail' | 'running';
+  created_date?: Date | string;
+  end_date?: Date | string;
+  error?: string;
+};
 
 export interface ChatkitMessage {
-  status?: string
-  content: TMessageItems | string
-  reasoning?: TMessageContentReasoning[]
-  type: 'user' | 'assistant' | 'system' | 'tool' | 'event'
-  id: string
+  status?: string;
+  content: TMessageItems | string;
+  reasoning?: TMessageContentReasoning[];
+  type: 'user' | 'assistant' | 'system' | 'tool' | 'event';
+  id: string;
 }
 
 export type TMessageItems = TMessageContentComplex[];
 
+export type ChatKitCodeReference = {
+  id?: string;
+  label?: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  text: string;
+  language?: string;
+  taskId?: string;
+};
 
-export const STATE_VARIABLE_HUMAN = 'human'
+export const STATE_VARIABLE_HUMAN = 'human';
 
 /**
  * Human input message, include parameters and attachments
  */
 export type TChatRequestHuman = {
-  input?: string
-  files?: Partial<File>[]
-  [key: string]: unknown
-}
+  input?: string;
+  files?: Partial<File>[];
+  [key: string]: unknown;
+};
 
 /**
  * Command to resume with streaming after human decision
  */
 export type TInterruptCommand = {
-  resume?: any
-  update?: any
-  toolCalls?: ToolCall[]
-  agentKey?: string
-}
+  resume?: any;
+  update?: any;
+  toolCalls?: ToolCall[];
+  agentKey?: string;
+};
 
 export type TChatRequest = {
   /**
    * The human input, include parameters
    */
-  input: TChatRequestHuman
+  input: TChatRequestHuman;
   /**
    * Custom graph state
    */
-  state?: {[STATE_VARIABLE_HUMAN]: TChatRequestHuman} & Record<string, any>
-  agentKey?: string
-  projectId?: string
-  conversationId?: string
-  environmentId?: string
-  id?: string
-  executionId?: string
-  confirm?: boolean
-  command?: TInterruptCommand
-  retry?: boolean
+  state?: { [STATE_VARIABLE_HUMAN]: TChatRequestHuman } & Record<string, any>;
+  agentKey?: string;
+  projectId?: string;
+  conversationId?: string;
+  environmentId?: string;
+  id?: string;
+  executionId?: string;
+  confirm?: boolean;
+  command?: TInterruptCommand;
+  retry?: boolean;
   /**
    * PRO: Sandbox Environment Id
    * PRO: @description Sandbox environment ID to force using the specified container.
    */
   sandboxEnvironmentId?: string;
-}
+};
 
 /**
  * Data type for client effect message
  */
 export type TClientEeffectMessage = {
-  name: string
-  args: Record<string, any>
-  tool_call_id?: string
+  name: string;
+  args: Record<string, any>;
+  tool_call_id?: string;
   agentKey?: string;
-  created_date?: Date | string
-}
+  created_date?: Date | string;
+};
 
 // Thread context usage
 export type TThreadContextUsageMetrics = {
-  contextTokens: number
-  inputTokens: number
-  outputTokens: number
-  totalTokens: number
-  embedTokens?: number
-  totalPrice?: number
-  currency?: string | null
-}
+  contextTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  embedTokens?: number;
+  totalPrice?: number;
+  currency?: string | null;
+};
 
 export type TThreadContextUsageEvent = {
-  type: 'thread_context_usage'
-  threadId: string
-  runId: string | null
-  agentKey: string
-  updatedAt: string
-  usage: TThreadContextUsageMetrics
-}
+  type: 'thread_context_usage';
+  threadId: string;
+  runId: string | null;
+  agentKey: string;
+  updatedAt: string;
+  usage: TThreadContextUsageMetrics;
+};

--- a/packages/web-component/src/ChatKitElementBase.ts
+++ b/packages/web-component/src/ChatKitElementBase.ts
@@ -26,6 +26,11 @@ import {
   fromPossibleFrameSafeError,
 } from '@xpert-ai/chatkit-web-shared';
 
+const HTMLElementBase =
+  typeof HTMLElement === 'undefined'
+    ? (class {} as typeof HTMLElement)
+    : HTMLElement;
+
 // Compute inner options by removing methods (to make options serializable)
 function getInnerOptions(options: ChatKitOptions): ChatKitInnerOptions {
   return removeMethods(options) as ChatKitInnerOptions;
@@ -71,7 +76,7 @@ interface ChatKitBaseElementEventMap {
   }>;
 }
 
-export abstract class ChatKitElementBase<TRawOptions> extends HTMLElement {
+export abstract class ChatKitElementBase<TRawOptions> extends HTMLElementBase {
   protected profile: ChatKitProfile;
   protected capabilities: Capabilities;
   protected abstract sanitizeOptions(options: TRawOptions): ChatKitOptions;

--- a/packages/web-component/src/ChatKitElementBase.ts
+++ b/packages/web-component/src/ChatKitElementBase.ts
@@ -1,8 +1,14 @@
-import { encodeBase64 } from "@xpert-ai/chatkit-web-shared"
+import { encodeBase64 } from '@xpert-ai/chatkit-web-shared';
 
-import { ChatFrameMessenger } from "./ChatFrameMessenger"
-import { Card, ChatKitOptions, Entity, ListView } from "@xpert-ai/chatkit-types"
-import { removeMethods } from "./helpers"
+import { ChatFrameMessenger } from './ChatFrameMessenger';
+import {
+  Card,
+  ChatKitCodeReference,
+  ChatKitOptions,
+  Entity,
+  ListView,
+} from '@xpert-ai/chatkit-types';
+import { removeMethods } from './helpers';
 
 import type {
   Attachment,
@@ -12,14 +18,17 @@ import type {
   ChatKitReq,
   UserMessageContent,
   ToolChoice,
-} from "@xpert-ai/chatkit-web-shared"
-import { getCapabilities } from "@xpert-ai/chatkit-web-shared"
-import type { Capabilities, Capability } from "@xpert-ai/chatkit-web-shared"
-import { IntegrationError, fromPossibleFrameSafeError } from "@xpert-ai/chatkit-web-shared"
+} from '@xpert-ai/chatkit-web-shared';
+import { getCapabilities } from '@xpert-ai/chatkit-web-shared';
+import type { Capabilities, Capability } from '@xpert-ai/chatkit-web-shared';
+import {
+  IntegrationError,
+  fromPossibleFrameSafeError,
+} from '@xpert-ai/chatkit-web-shared';
 
 // Compute inner options by removing methods (to make options serializable)
 function getInnerOptions(options: ChatKitOptions): ChatKitInnerOptions {
-  return removeMethods(options) as ChatKitInnerOptions
+  return removeMethods(options) as ChatKitInnerOptions;
 }
 
 // Decorator to assert that a command is available for the current capabilities profile
@@ -29,72 +38,86 @@ export function requireCommandCapability<
   Return,
 >(
   value: (this: This, ...args: Args) => Return,
-  context: ClassMethodDecoratorContext<This, (this: This, ...args: Args) => Return>,
+  context: ClassMethodDecoratorContext<
+    This,
+    (this: This, ...args: Args) => Return
+  >,
 ) {
-  const command = String(context.name)
+  const command = String(context.name);
   return function (this: This, ...args: Args) {
     if (!this.capabilities.commands.has(command as Capability.Command)) {
       throw new IntegrationError(
         `ChatKit command "${String(command)}" is not available for the "${this.profile}" profile.`,
-      )
+      );
     }
-    return value.apply(this, args)
-  }
+    return value.apply(this, args);
+  };
 }
 
 interface ChatKitBaseElementEventMap {
-  "chatkit.ready": CustomEvent<void>
-  "chatkit.error": CustomEvent<{ error: Error }>
-  "chatkit.response.start": CustomEvent<void>
-  "chatkit.response.end": CustomEvent<void>
-  "chatkit.thread.change": CustomEvent<{ threadId: string | null }>
-  "chatkit.log": CustomEvent<{ name: string; data?: Record<string, unknown> }>
-  "chatkit.deeplink": CustomEvent<{ name: string; data?: Record<string, unknown> }>
-  "chatkit.widget.action": CustomEvent<{ action: string; payload?: Record<string, unknown> }>
+  'chatkit.ready': CustomEvent<void>;
+  'chatkit.error': CustomEvent<{ error: Error }>;
+  'chatkit.response.start': CustomEvent<void>;
+  'chatkit.response.end': CustomEvent<void>;
+  'chatkit.thread.change': CustomEvent<{ threadId: string | null }>;
+  'chatkit.log': CustomEvent<{ name: string; data?: Record<string, unknown> }>;
+  'chatkit.deeplink': CustomEvent<{
+    name: string;
+    data?: Record<string, unknown>;
+  }>;
+  'chatkit.widget.action': CustomEvent<{
+    action: string;
+    payload?: Record<string, unknown>;
+  }>;
 }
 
 export abstract class ChatKitElementBase<TRawOptions> extends HTMLElement {
-  protected profile: ChatKitProfile
-  protected capabilities: Capabilities
-  protected abstract sanitizeOptions(options: TRawOptions): ChatKitOptions
+  protected profile: ChatKitProfile;
+  protected capabilities: Capabilities;
+  protected abstract sanitizeOptions(options: TRawOptions): ChatKitOptions;
 
-  #opts?: ChatKitOptions
-  #frameUrl?: string
-  #frame?: HTMLIFrameElement
-  #wrapper?: HTMLDivElement
+  #opts?: ChatKitOptions;
+  #frameUrl?: string;
+  #frame?: HTMLIFrameElement;
+  #wrapper?: HTMLDivElement;
 
-  #shadow = this.attachShadow({ mode: "open" })
+  #shadow = this.attachShadow({ mode: 'open' });
 
-  #resolveLoaded?: () => void
+  #resolveLoaded?: () => void;
   #loaded = new Promise<void>((resolve) => {
-    this.#resolveLoaded = resolve
-  })
+    this.#resolveLoaded = resolve;
+  });
 
   #messenger = new ChatFrameMessenger({
     fetch: ((...args) => {
-      const customFetch = this.#opts?.api && "fetch" in this.#opts.api && this.#opts.api.fetch
-      return customFetch ? customFetch(...args) : fetch(...args)
+      const customFetch =
+        this.#opts?.api && 'fetch' in this.#opts.api && this.#opts.api.fetch;
+      return customFetch ? customFetch(...args) : fetch(...args);
     }) as typeof fetch,
     target: () => this.#frame?.contentWindow ?? null,
     targetOrigin: window.location.origin,
     handlers: {
-      onFileInputClick: ({ inputAttributes }: { inputAttributes: Record<string, string> }) => {
+      onFileInputClick: ({
+        inputAttributes,
+      }: {
+        inputAttributes: Record<string, string>;
+      }) => {
         return new Promise<File[]>((resolve) => {
-          const input = document.createElement("input")
+          const input = document.createElement('input');
           for (const [key, value] of Object.entries(inputAttributes)) {
-            input.setAttribute(key, String(value))
+            input.setAttribute(key, String(value));
           }
           const respond = () => {
-            resolve(Array.from(input.files || []))
+            resolve(Array.from(input.files || []));
             if (this.#shadow.contains(input)) {
-              this.#shadow.removeChild(input)
+              this.#shadow.removeChild(input);
             }
-          }
-          input.addEventListener("cancel", respond)
-          input.addEventListener("change", respond)
-          this.#shadow.appendChild(input)
-          input.click()
-        })
+          };
+          input.addEventListener('cancel', respond);
+          input.addEventListener('change', respond);
+          this.#shadow.appendChild(input);
+          input.click();
+        });
       },
       onClientToolCall: async ({
         name,
@@ -102,67 +125,77 @@ export abstract class ChatKitElementBase<TRawOptions> extends HTMLElement {
         id,
         tool_call_id,
       }: {
-        name: string
-        params: Record<string, unknown>
-        id?: string
-        tool_call_id?: string
+        name: string;
+        params: Record<string, unknown>;
+        id?: string;
+        tool_call_id?: string;
       }) => {
-        const onClientTool = this.#opts?.onClientTool
+        const onClientTool = this.#opts?.onClientTool;
         if (!onClientTool) {
           this.#emitAndThrow(
             new IntegrationError(
               `No handler for client tool calls. You'll need to add onClientTool to your ChatKit options.`,
             ),
-          )
+          );
         }
-        return onClientTool({ name, params, id, tool_call_id })
+        return onClientTool({ name, params, id, tool_call_id });
       },
-      onWidgetAction: async ({ action, widgetItem }: { action: {
+      onWidgetAction: async ({
+        action,
+        widgetItem,
+      }: {
+        action: {
           type: string;
           payload?: Record<string, unknown> | undefined;
-        }; widgetItem: {
-            id: string;
-            widget: Card | ListView;
-      } }) => {
-        const onAction = this.#opts?.widgets?.onAction
+        };
+        widgetItem: {
+          id: string;
+          widget: Card | ListView;
+        };
+      }) => {
+        const onAction = this.#opts?.widgets?.onAction;
         if (!onAction) {
           this.#emitAndThrow(
             new IntegrationError(
               `No handler for widget actions. You'll need to add widgets.onAction to your ChatKit options.`,
             ),
-          )
+          );
         }
-        return onAction(action, widgetItem)
+        return onAction(action, widgetItem);
       },
-      onEntitySearch: async ({ query }: { query: string }) => this.#opts?.entities?.onTagSearch?.(query) ?? [],
-      onEntityClick: async ({ entity }: { entity: Entity }) => this.#opts?.entities?.onClick?.(entity),
+      onEntitySearch: async ({ query }: { query: string }) =>
+        this.#opts?.entities?.onTagSearch?.(query) ?? [],
+      onEntityClick: async ({ entity }: { entity: Entity }) =>
+        this.#opts?.entities?.onClick?.(entity),
       onEntityPreview: async ({ entity }: { entity: Entity }) =>
         this.#opts?.entities?.onRequestPreview?.(entity) ?? { preview: null },
       onGetClientSecret: async (currentClientSecret: string | null) => {
         if (
           !this.#opts ||
-          !("getClientSecret" in this.#opts.api) ||
+          !('getClientSecret' in this.#opts.api) ||
           !this.#opts.api.getClientSecret
         ) {
           // ~Impossible since the existence of this handler is the only way
           // that we end up creating the kind of ApiClient that would call this handler in the first place.
           this.#emitAndThrow(
             new IntegrationError(
-              "Could not refresh the session because ChatKitOptions.api.getClientSecret is not configured.",
+              'Could not refresh the session because ChatKitOptions.api.getClientSecret is not configured.',
             ),
-          )
+          );
         }
 
-        return this.#opts.api.getClientSecret(currentClientSecret ?? null)
+        return this.#opts.api.getClientSecret(currentClientSecret ?? null);
       },
       onAddMetadataToRequest: ({
         op,
         params,
       }: {
-        op: ChatKitReq["type"]
-        params: Record<string, unknown>
+        op: ChatKitReq['type'];
+        params: Record<string, unknown>;
       }): void => {
-        throw new IntegrationError('ChatKit: onAddMetadataToRequest is unimplemented.')
+        throw new IntegrationError(
+          'ChatKit: onAddMetadataToRequest is unimplemented.',
+        );
         // if (!this.#opts) return null
         // if (!("addMetadataToRequest" in this.#opts.api) || !this.#opts.api.addMetadataToRequest)
         //   return null
@@ -181,66 +214,72 @@ export abstract class ChatKitElementBase<TRawOptions> extends HTMLElement {
         // })
       },
     },
-  })
+  });
 
   constructor({ profile }: { profile: ChatKitProfile }) {
-    super()
-    this.profile = profile
-    this.capabilities = getCapabilities(profile)
+    super();
+    this.profile = profile;
+    this.capabilities = getCapabilities(profile);
   }
 
   protected setProfile(profile: ChatKitProfile) {
-    this.profile = profile
-    this.capabilities = getCapabilities(profile)
+    this.profile = profile;
+    this.capabilities = getCapabilities(profile);
   }
 
   #emitAndThrow(error: Error): never {
-    this.dispatchEvent(new CustomEvent("chatkit.error", { detail: { error } }))
-    throw error
+    this.dispatchEvent(new CustomEvent('chatkit.error', { detail: { error } }));
+    throw error;
   }
 
   #setOptionsDataAttributes(options: ChatKitOptions) {
     this.dataset.colorScheme =
-      typeof options.theme === "string" ? options.theme : options.theme?.colorScheme ?? "light"
+      typeof options.theme === 'string'
+        ? options.theme
+        : (options.theme?.colorScheme ?? 'light');
   }
 
   #getFrameUrl() {
     if (!this.#frameUrl) {
       throw new IntegrationError(
-        "ChatKit frameUrl is not configured. Provide it via setOptions({ frameUrl }) before mounting.",
-      )
+        'ChatKit frameUrl is not configured. Provide it via setOptions({ frameUrl }) before mounting.',
+      );
     }
-    return this.#frameUrl
+    return this.#frameUrl;
   }
 
   #setFrameUrl(frameUrl: string) {
     if (this.#initialized && this.#frameUrl && this.#frameUrl !== frameUrl) {
       throw new IntegrationError(
-        "ChatKit frameUrl cannot be changed after initialization. Create a new element to use a different URL.",
-      )
+        'ChatKit frameUrl cannot be changed after initialization. Create a new element to use a different URL.',
+      );
     }
-    this.#frameUrl = frameUrl
+    this.#frameUrl = frameUrl;
   }
 
   #consumeFrameUrl(options: ChatKitOptions) {
-    if (!("frameUrl" in options)) return
-    const frameUrl = options.frameUrl
-    delete options.frameUrl
-    if (frameUrl == null) return
-    if (typeof frameUrl !== "string" || frameUrl.trim() === "") {
-      throw new IntegrationError("ChatKit frameUrl must be a non-empty string.")
+    if (!('frameUrl' in options)) return;
+    const frameUrl = options.frameUrl;
+    delete options.frameUrl;
+    if (frameUrl == null) return;
+    if (typeof frameUrl !== 'string' || frameUrl.trim() === '') {
+      throw new IntegrationError(
+        'ChatKit frameUrl must be a non-empty string.',
+      );
     }
-    this.#setFrameUrl(frameUrl)
+    this.#setFrameUrl(frameUrl);
   }
 
   #handleFrameLoad = () => {
-    this.dataset.loaded = "true"
-    this.dispatchEvent(new CustomEvent("chatkit.ready", { bubbles: true, composed: true }))
-    this.#resolveLoaded?.()
-  }
+    this.dataset.loaded = 'true';
+    this.dispatchEvent(
+      new CustomEvent('chatkit.ready', { bubbles: true, composed: true }),
+    );
+    this.#resolveLoaded?.();
+  };
 
   connectedCallback() {
-    const style = document.createElement("style")
+    const style = document.createElement('style');
     style.textContent = `
       :host {
         display: block;
@@ -271,189 +310,199 @@ export abstract class ChatKitElementBase<TRawOptions> extends HTMLElement {
       :host([data-loaded="true"]) .ck-wrapper {
         opacity: 1;
       }
-    `
+    `;
 
-    const frame = document.createElement("iframe")
-    frame.className = "ck-iframe"
-    frame.name = "chatkit"
-    frame.role = "presentation"
-    frame.tabIndex = 0
-    frame.setAttribute("allowtransparency", "true")
-    frame.setAttribute("frameborder", "0")
-    frame.setAttribute("scrolling", "no")
-    frame.setAttribute("allow", "clipboard-read; clipboard-write")
-    this.#frame = frame
+    const frame = document.createElement('iframe');
+    frame.className = 'ck-iframe';
+    frame.name = 'chatkit';
+    frame.role = 'presentation';
+    frame.tabIndex = 0;
+    frame.setAttribute('allowtransparency', 'true');
+    frame.setAttribute('frameborder', '0');
+    frame.setAttribute('scrolling', 'no');
+    frame.setAttribute('allow', 'clipboard-read; clipboard-write');
+    this.#frame = frame;
 
     // not sure we still need this..
-    const wrapper = document.createElement("div")
-    wrapper.className = "ck-wrapper"
-    wrapper.appendChild(frame)
-    this.#wrapper = wrapper
+    const wrapper = document.createElement('div');
+    wrapper.className = 'ck-wrapper';
+    wrapper.appendChild(frame);
+    this.#wrapper = wrapper;
 
-    this.#shadow.append(style)
+    this.#shadow.append(style);
 
     if (import.meta.env.DEV) {
-      this.#messenger.on("development_only_force_page_reload", () => {
-        window.location.reload()
-      })
+      this.#messenger.on('development_only_force_page_reload', () => {
+        window.location.reload();
+      });
     }
-    this.#messenger.on("left_header_icon_click", () => {
-      this.#opts?.header?.leftAction?.onClick()
-    })
-    this.#messenger.on("right_header_icon_click", () => {
-      this.#opts?.header?.rightAction?.onClick()
-    })
-    this.#messenger.on("public_event", ([event, data]) => {
-      if (!this.capabilities.events.has(event)) return
-      if (event === "error" && "error" in data) {
+    this.#messenger.on('left_header_icon_click', () => {
+      this.#opts?.header?.leftAction?.onClick();
+    });
+    this.#messenger.on('right_header_icon_click', () => {
+      this.#opts?.header?.rightAction?.onClick();
+    });
+    this.#messenger.on('public_event', ([event, data]) => {
+      if (!this.capabilities.events.has(event)) return;
+      if (event === 'error' && 'error' in data) {
         // Custom error handling to convert frame-safe errors back into real Errors
-        const error = fromPossibleFrameSafeError(data.error)
-        this.dispatchEvent(new CustomEvent("chatkit.error", { detail: { error } }))
+        const error = fromPossibleFrameSafeError(data.error);
+        this.dispatchEvent(
+          new CustomEvent('chatkit.error', { detail: { error } }),
+        );
         // IntegrationErrors should throw
         if (error instanceof IntegrationError) {
-          throw error
+          throw error;
         }
-        return
+        return;
       }
 
-      this.dispatchEvent(new CustomEvent(`chatkit.${event}`, { detail: data }))
-    })
-    this.#messenger.on("unmount", () => {
+      this.dispatchEvent(new CustomEvent(`chatkit.${event}`, { detail: data }));
+    });
+    this.#messenger.on('unmount', () => {
       // Remove the iframe and wrapper from the shadow DOM if they exist
       if (this.#wrapper && this.#shadow.contains(this.#wrapper)) {
-        this.#shadow.removeChild(this.#wrapper)
-        this.#wrapper = undefined
-        this.#frame = undefined
+        this.#shadow.removeChild(this.#wrapper);
+        this.#wrapper = undefined;
+        this.#frame = undefined;
       }
-    })
+    });
     this.#messenger.on(
-      "capabilities_profile_change",
+      'capabilities_profile_change',
       ({ profile }: { profile: ChatKitProfile }) => {
-        this.setProfile(profile)
+        this.setProfile(profile);
       },
-    )
+    );
 
-    frame.addEventListener("load", this.#handleFrameLoad, { once: true })
+    frame.addEventListener('load', this.#handleFrameLoad, { once: true });
 
     try {
-      this.#maybeInit()
+      this.#maybeInit();
     } catch (error) {
-      console.error(error)
+      console.error(error);
       this.#emitAndThrow(
-        error instanceof Error ? error : new IntegrationError("Failed to initialize ChatKit"),
-      )
+        error instanceof Error
+          ? error
+          : new IntegrationError('Failed to initialize ChatKit'),
+      );
     }
   }
 
-  #initialized = false
+  #initialized = false;
   #maybeInit() {
     if (this.#initialized || !this.#frame || !this.#opts) {
-      return
+      return;
     }
-    this.#initialized = true
-    this.#setOptionsDataAttributes(this.#opts)
-    const frameURL = new URL(this.#getFrameUrl(), window.location.origin)
-    this.#messenger.setTargetOrigin(frameURL.origin)
+    this.#initialized = true;
+    this.#setOptionsDataAttributes(this.#opts);
+    const frameURL = new URL(this.#getFrameUrl(), window.location.origin);
+    this.#messenger.setTargetOrigin(frameURL.origin);
     frameURL.hash = encodeBase64({
       options: getInnerOptions(this.#opts),
       referrer: window.location.origin,
       profile: this.profile,
-    } satisfies ChatKitFrameParams)
-    this.#messenger.connect()
-    this.#frame.src = frameURL.toString()
+    } satisfies ChatKitFrameParams);
+    this.#messenger.connect();
+    this.#frame.src = frameURL.toString();
     // Impossible to not exist
     if (this.#wrapper) {
-      this.#shadow.append(this.#wrapper)
+      this.#shadow.append(this.#wrapper);
     }
   }
 
   disconnectedCallback() {
-    this.#frame?.removeEventListener("load", this.#handleFrameLoad)
-    this.#messenger.disconnect()
+    this.#frame?.removeEventListener('load', this.#handleFrameLoad);
+    this.#messenger.disconnect();
   }
 
   protected applySanitizedOptions(newOptions: ChatKitOptions) {
-    this.#opts = newOptions
+    this.#opts = newOptions;
     if (this.#initialized) {
-      this.#setOptionsDataAttributes(this.#opts)
+      this.#setOptionsDataAttributes(this.#opts);
       this.#loaded.then(() => {
-        this.#messenger.commands.setOptions(getInnerOptions(newOptions))
-      })
+        this.#messenger.commands.setOptions(getInnerOptions(newOptions));
+      });
     } else {
-      this.#maybeInit()
+      this.#maybeInit();
     }
   }
 
   setOptions(newOptions: TRawOptions) {
     try {
-      const sanitized = this.sanitizeOptions(newOptions)
-      this.#consumeFrameUrl(sanitized)
-      this.applySanitizedOptions(sanitized)
+      const sanitized = this.sanitizeOptions(newOptions);
+      this.#consumeFrameUrl(sanitized);
+      this.applySanitizedOptions(sanitized);
     } catch (error) {
       this.#emitAndThrow(
-        error instanceof Error ? error : new IntegrationError("Failed to parse options"),
-      )
+        error instanceof Error
+          ? error
+          : new IntegrationError('Failed to parse options'),
+      );
     }
   }
 
   @requireCommandCapability
   async focusComposer() {
-    await this.#loaded
-    this.#frame?.focus()
-    await this.#messenger?.commands.focusComposer()
+    await this.#loaded;
+    this.#frame?.focus();
+    await this.#messenger?.commands.focusComposer();
   }
 
   @requireCommandCapability
   async fetchUpdates() {
-    await this.#loaded
-    await this.#messenger?.commands.fetchUpdates()
+    await this.#loaded;
+    await this.#messenger?.commands.fetchUpdates();
   }
 
   @requireCommandCapability
   async sendUserMessage(params: {
-    text?: string
-    content?: UserMessageContent[]
-    reply?: string
-    attachments?: Attachment[]
-    toolChoice?: ToolChoice
-    model?: string
-    newThread?: boolean
+    text?: string;
+    content?: UserMessageContent[];
+    reply?: string;
+    attachments?: Attachment[];
+    toolChoice?: ToolChoice;
+    model?: string;
+    newThread?: boolean;
     /** Trigger parameters from workflow trigger configuration */
-    trigger?: {
-      name?: string
-      params?: Record<string, any>
-    } | Record<string, any>
+    trigger?:
+      | {
+          name?: string;
+          params?: Record<string, any>;
+        }
+      | Record<string, any>;
     /** Custom state variables for workflow */
-    state?: Record<string, any>
+    state?: Record<string, any>;
   }) {
-    await this.#loaded
-    await this.#messenger?.commands.sendUserMessage(params)
+    await this.#loaded;
+    await this.#messenger?.commands.sendUserMessage(params);
   }
 
   @requireCommandCapability
   async setComposerValue(params: {
-    text?: string
-    content?: UserMessageContent[]
-    reply?: string
-    attachments?: Attachment[]
-    files?: File[]
-    selectedToolId?: string
-    selectedModelId?: string
+    text?: string;
+    content?: UserMessageContent[];
+    reply?: string;
+    attachments?: Attachment[];
+    references?: ChatKitCodeReference[];
+    appendReferences?: boolean;
+    files?: File[];
+    selectedToolId?: string;
+    selectedModelId?: string;
   }) {
-    await this.#loaded
-    await this.#messenger?.commands.setComposerValue(params)
+    await this.#loaded;
+    await this.#messenger?.commands.setComposerValue(params);
   }
 
   @requireCommandCapability
   async setThreadId(threadId: string | null) {
-    await this.#loaded
-    await this.#messenger?.commands.setThreadId({ threadId })
+    await this.#loaded;
+    await this.#messenger?.commands.setThreadId({ threadId });
   }
 
   @requireCommandCapability
   async shareThread() {
-    await this.#loaded
-    return this.#messenger?.commands.shareThread()
+    await this.#loaded;
+    return this.#messenger?.commands.shareThread();
   }
 
   @requireCommandCapability
@@ -461,31 +510,33 @@ export abstract class ChatKitElementBase<TRawOptions> extends HTMLElement {
     action: { type: string; payload?: Record<string, unknown> },
     itemId?: string,
   ) {
-    await this.#loaded
-    return this.#messenger?.commands.sendCustomAction({ action, itemId })
+    await this.#loaded;
+    return this.#messenger?.commands.sendCustomAction({ action, itemId });
   }
 
   @requireCommandCapability
   async showHistory() {
-    await this.#loaded
-    return this.#messenger?.commands.showHistory()
+    await this.#loaded;
+    return this.#messenger?.commands.showHistory();
   }
 
   @requireCommandCapability
   async hideHistory() {
-    await this.#loaded
-    return this.#messenger?.commands.hideHistory()
+    await this.#loaded;
+    return this.#messenger?.commands.hideHistory();
   }
 
   @requireCommandCapability
   async setTrainingOptOut(value: boolean) {
-    await this.#loaded
-    return this.#messenger?.commands.setTrainingOptOut({ value })
+    await this.#loaded;
+    return this.#messenger?.commands.setTrainingOptOut({ value });
   }
 }
 
-export interface ChatKitBaseElement<TRawOptions, TSanitizedOptions extends ChatKitOptions>
-  extends HTMLElement {
+export interface ChatKitBaseElement<
+  TRawOptions,
+  TSanitizedOptions extends ChatKitOptions,
+> extends HTMLElement {
   addEventListener<K extends keyof ChatKitBaseElementEventMap>(
     type: K,
     listener: (
@@ -493,7 +544,7 @@ export interface ChatKitBaseElement<TRawOptions, TSanitizedOptions extends ChatK
       ev: ChatKitBaseElementEventMap[K],
     ) => void,
     options?: boolean | AddEventListenerOptions,
-  ): void
+  ): void;
 
   removeEventListener<K extends keyof ChatKitBaseElementEventMap>(
     type: K,
@@ -502,5 +553,5 @@ export interface ChatKitBaseElement<TRawOptions, TSanitizedOptions extends ChatK
       ev: ChatKitBaseElementEventMap[K],
     ) => void,
     options?: boolean | EventListenerOptions,
-  ): void
+  ): void;
 }

--- a/packages/web-component/src/index.ts
+++ b/packages/web-component/src/index.ts
@@ -1,1 +1,5 @@
+import { ChatKitElement, registerChatKitElement } from './ChatKitElement'
 
+registerChatKitElement()
+
+export { ChatKitElement, registerChatKitElement }


### PR DESCRIPTION
## Summary
- add code reference support to the ChatKit composer API
- render and merge code reference chips in chatkit-ui before sending human messages
- plumb reference payloads through the parent messenger, stream layer, and web component surface

## Why
This lets downstream products inject selected code snippets into ChatKit as structured context instead of manually concatenating prompt text.

## Validation
- `pnpm --filter @xpert-ai/chatkit-types build`
- `pnpm --filter @xpert-ai/chatkit-ui build`
- `pnpm --filter @xpert-ai/chatkit-ui test`

## Notes
- `.gitignore` and Docker-related local changes were intentionally excluded from this PR.
- `pnpm --filter @xpert-ai/chatkit-ui lint`
- `pnpm --filter @xpert-ai/chatkit-ui types`
- `pnpm --filter @xpert-ai/chatkit-web-component build`

The commands above still hit pre-existing repo issues outside the scope of this change, so they were not used as merge blockers here.