### PR TITLE
fix: handle invalid widget surfaces

### DIFF
--- a/.changeset/invalid-widget-surface.md
+++ b/.changeset/invalid-widget-surface.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/chatkit-ui": patch
+---
+
+Handle invalid widget surfaces without crashing message rendering.

--- a/packages/chatkit-ui/src/components/thread/messages/widget.test.tsx
+++ b/packages/chatkit-ui/src/components/thread/messages/widget.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { A2UIProvider, Types } from '@xpert-ai/a2ui-react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { WidgetMessage } from './widget';
 
 function renderWidget(data: Parameters<typeof WidgetMessage>[0]['data']) {
@@ -114,6 +114,28 @@ describe('WidgetMessage', () => {
     expect(await screen.findByText('42734.32')).toBeInTheDocument();
   });
 
+  it('shows fallback when flat widget messages contain invalid component references', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      renderWidget({
+        type: 'Widget',
+        widgets: [
+          {
+            name: 'generated_surface',
+            messages: createInvalidGeneratedSurfaceMessages(),
+          },
+        ],
+      });
+
+      expect(
+        await screen.findByText('Widget failed to render.'),
+      ).toBeInTheDocument();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('keeps rendering legacy pre-resolved surfaces', async () => {
     renderWidget({
       type: 'Widget',
@@ -157,6 +179,44 @@ function createTextSurfaceMessages(
               Text: { text: { literalString: text } },
             },
           },
+        ],
+      },
+    },
+    {
+      beginRendering: {
+        surfaceId: '@default',
+        root: 'root',
+      },
+    },
+  ];
+}
+
+function createInvalidGeneratedSurfaceMessages(): Types.ServerToClientMessage[] {
+  return [
+    {
+      dataModelUpdate: {
+        surfaceId: '@default',
+        path: '/',
+        contents: [
+          { key: 'title', valueString: 'CEO Daily Brief' },
+          { key: 'summary', valueString: 'Daily operating summary.' },
+          { key: 'section1_title', valueString: '1. Key findings' },
+          { key: 'section1_content', valueString: 'Revenue increased today.' },
+        ],
+      },
+    },
+    {
+      surfaceUpdate: {
+        surfaceId: '@default',
+        components: [
+          column('root', [
+            'title',
+            'summary',
+            'divider1',
+            'section1_title',
+            'section1_content',
+          ]),
+          divider('divider1'),
         ],
       },
     },

--- a/packages/chatkit-ui/src/components/thread/messages/widget.tsx
+++ b/packages/chatkit-ui/src/components/thread/messages/widget.tsx
@@ -1,5 +1,5 @@
 import type { TMessageComponentWidgetData } from '@xpert-ai/chatkit-types';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   A2UIRenderer,
   SurfaceRenderer,
@@ -64,6 +64,7 @@ function FlatWidgetSurface({
   surfaceId: string;
 }) {
   const { processMessages } = useA2UI();
+  const [renderError, setRenderError] = useState(false);
   const normalizedMessages = useMemo(
     () => normalizeFlatWidgetMessages(messages, surfaceId),
     [messages, surfaceId],
@@ -72,13 +73,39 @@ function FlatWidgetSurface({
   useEffect(() => {
     if (normalizedMessages.length === 0) return;
 
-    processMessages(normalizedMessages);
+    setRenderError(false);
+    try {
+      processMessages(normalizedMessages);
+    } catch (error) {
+      console.warn('[chatkit-ui] Failed to render widget surface', {
+        surfaceId,
+        error,
+      });
+      setRenderError(true);
+      return;
+    }
+
     return () => {
       processMessages([{ deleteSurface: { surfaceId } }]);
     };
   }, [normalizedMessages, processMessages, surfaceId]);
 
+  if (renderError) {
+    return <WidgetRenderErrorFallback />;
+  }
+
   return <A2UIRenderer surfaceId={surfaceId} />;
+}
+
+function WidgetRenderErrorFallback() {
+  return (
+    <div
+      role="alert"
+      className="rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-xs text-destructive"
+    >
+      Widget failed to render.
+    </div>
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- catch A2UI processing failures for invalid flat widget surfaces
- show a scoped widget fallback instead of crashing message rendering
- add a regression test and patch changeset for chatkit-ui

## Validation
- pnpm --filter @xpert-ai/chatkit-ui exec vitest run src/components/thread/messages/widget.test.tsx
- pnpm --filter @xpert-ai/chatkit-ui types