### PR TITLE
[codex] fix chatkit agent run history state

### DIFF
--- a/.changeset/fix-chatkit-agent-run-history.md
+++ b/.changeset/fix-chatkit-agent-run-history.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/chatkit-ui": patch
+---
+
+Fix persisted agent run status and duration rendering in ChatKit history.

--- a/packages/chatkit-ui/src/components/thread/messages/agent-run-group.tsx
+++ b/packages/chatkit-ui/src/components/thread/messages/agent-run-group.tsx
@@ -329,15 +329,41 @@ export function AgentRunGroup({
   );
   const StatusIcon = statusConfig.icon;
   const isRunning = isRunningRunStatus(node.info.status);
+  const hasStaticDuration =
+    typeof node.info.elapsedTime === 'number' &&
+    Number.isFinite(node.info.elapsedTime);
+  const hasDurationStartTimestamp =
+    node.info.startedAt !== undefined || node.info.createdAt !== undefined;
+  const shouldUpdateDuration =
+    isRunning && hasDurationStartTimestamp && !hasStaticDuration;
+  const [durationNow, setDurationNow] = React.useState(() => Date.now());
   const [isExpanded, setIsExpanded] = React.useState(
     () => isRunning || !hasFollowingItem,
   );
   const title = getAgentRunTitle(node.info, t('message.agentRun.defaultTitle'));
-  const duration = getAgentRunDuration(node.info);
+  const duration = getAgentRunDuration(
+    node.info,
+    shouldUpdateDuration ? durationNow : undefined,
+  );
   const statusLabel = t(`message.agentRun.status.${statusConfig.labelKey}`, {
     defaultValue: node.info.status ?? statusConfig.labelKey,
   });
   const detailsId = React.useId();
+
+  React.useEffect(() => {
+    if (!shouldUpdateDuration) {
+      return;
+    }
+
+    setDurationNow(Date.now());
+    const timer = window.setInterval(() => {
+      setDurationNow(Date.now());
+    }, 100);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [shouldUpdateDuration]);
 
   React.useEffect(() => {
     if (isRunning) {

--- a/packages/chatkit-ui/src/components/thread/messages/ai.test.tsx
+++ b/packages/chatkit-ui/src/components/thread/messages/ai.test.tsx
@@ -1405,6 +1405,60 @@ describe('AssistantMessage tool components', () => {
     expect(screen.getByText('2.5s')).toBeInTheDocument();
   });
 
+  it('updates the running agent run duration over time', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-24T12:24:54.398Z'));
+
+    renderAssistant([], {
+      executionId: 'root-exec',
+      agentRuns: [
+        {
+          id: 'exec-a',
+          parentId: 'root-exec',
+          title: 'Researcher',
+          status: 'running',
+          createdAt: '2026-04-24T12:24:52.898Z',
+          updatedAt: '2026-04-24T12:24:52.898Z',
+        },
+      ],
+    });
+
+    expect(
+      screen.getByRole('button', { name: /Researcher/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('1.5s')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+
+    expect(screen.getByText('2.5s')).toBeInTheDocument();
+  });
+
+  it('does not start an agent run duration timer without a start timestamp', () => {
+    vi.useFakeTimers();
+    const setIntervalSpy = vi.spyOn(window, 'setInterval');
+
+    renderAssistant([], {
+      executionId: 'root-exec',
+      agentRuns: [
+        {
+          id: 'exec-a',
+          parentId: 'root-exec',
+          title: 'Researcher',
+          status: 'running',
+        },
+      ],
+    });
+
+    expect(
+      screen.getByRole('button', { name: /Researcher/ }),
+    ).toBeInTheDocument();
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+
+    setIntervalSpy.mockRestore();
+  });
+
   it('groups interleaved sub-agent output by execution id', () => {
     renderAssistant(
       [

--- a/packages/chatkit-ui/src/lib/agent-run-render-tree.test.ts
+++ b/packages/chatkit-ui/src/lib/agent-run-render-tree.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAssistantRenderTree,
+  type AgentRunRenderNode,
+  type AssistantMessageWithAgentRuns,
+} from './agent-run-render-tree';
+
+function getAgentNodes(
+  message: AssistantMessageWithAgentRuns,
+): AgentRunRenderNode[] {
+  return buildAssistantRenderTree(message).units
+    .filter((item) => item.type === 'agent')
+    .map((item) => item.node);
+}
+
+describe('buildAssistantRenderTree', () => {
+  it('marks incomplete grouped agent nodes successful when the saved message completed', () => {
+    const nodes = getAgentNodes({
+      id: 'message-1',
+      type: 'assistant',
+      status: 'success',
+      executionId: 'root-execution',
+      agentRuns: [
+        {
+          id: 'pending-execution',
+          parentId: 'root-execution',
+          status: 'pending',
+        },
+      ],
+      content: [
+        {
+          id: 'created-from-content',
+          type: 'component',
+          executionId: 'child-execution',
+          parentExecutionId: 'root-execution',
+          agentKey: 'child-agent',
+          xpertName: 'single file agent',
+          data: {
+            id: 'created-from-content',
+            category: 'Tool',
+            title: 'read file',
+          },
+        },
+        {
+          id: 'explicit-pending',
+          type: 'component',
+          executionId: 'pending-execution',
+          parentExecutionId: 'root-execution',
+          agentKey: 'pending-agent',
+          xpertName: 'pending agent',
+          data: {
+            id: 'explicit-pending',
+            category: 'Tool',
+            title: 'write file',
+          },
+        },
+      ],
+    });
+
+    expect(nodes.map((node) => node.info.status)).toEqual([
+      'success',
+      'success',
+    ]);
+  });
+
+  it('does not infer completion while the assistant message is still running', () => {
+    const nodes = getAgentNodes({
+      id: 'message-1',
+      type: 'assistant',
+      status: 'running',
+      executionId: 'root-execution',
+      content: [
+        {
+          type: 'text',
+          text: 'file processing',
+          executionId: 'child-execution',
+          parentExecutionId: 'root-execution',
+          agentKey: 'child-agent',
+          xpertName: 'single file agent',
+        },
+      ],
+    });
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.info.status).toBeUndefined();
+  });
+});

--- a/packages/chatkit-ui/src/lib/agent-run-render-tree.ts
+++ b/packages/chatkit-ui/src/lib/agent-run-render-tree.ts
@@ -130,7 +130,7 @@ export function getAgentRunTitle(info: AgentRunInfo, fallback?: string) {
   );
 }
 
-export function getAgentRunDuration(info: AgentRunInfo) {
+export function getAgentRunDuration(info: AgentRunInfo, now?: number) {
   if (
     typeof info.elapsedTime === 'number' &&
     Number.isFinite(info.elapsedTime)
@@ -140,9 +140,16 @@ export function getAgentRunDuration(info: AgentRunInfo) {
 
   const startedAt =
     parseDateValue(info.startedAt) ?? parseDateValue(info.createdAt);
-  const endedAt = parseDateValue(info.endedAt) ?? parseDateValue(info.updatedAt);
+  if (startedAt === null) return null;
 
-  if (startedAt === null || endedAt === null) return null;
+  if (isRunningRunStatus(info.status)) {
+    return typeof now === 'number' && Number.isFinite(now)
+      ? Math.max(0, now - startedAt)
+      : null;
+  }
+
+  const endedAt = parseDateValue(info.endedAt) ?? parseDateValue(info.updatedAt);
+  if (endedAt === null) return null;
   return Math.max(0, endedAt - startedAt);
 }
 
@@ -353,6 +360,14 @@ function refreshAgentNodeOrder(node: AgentRunRenderNode): number {
   return order;
 }
 
+function markIncompleteAgentRunStatusSuccess(node: AgentRunRenderNode) {
+  if (normalizeRunStatus(node.info.status) === 'pending') {
+    node.info.status = 'success';
+  }
+
+  node.children.forEach(markIncompleteAgentRunStatusSuccess);
+}
+
 export function buildAssistantRenderTree(
   message: AssistantMessageWithAgentRuns,
 ) {
@@ -415,6 +430,9 @@ export function buildAssistantRenderTree(
   }
 
   roots.forEach(refreshAgentNodeOrder);
+  if (normalizeRunStatus(message.status) === 'success') {
+    roots.forEach(markIncompleteAgentRunStatusSuccess);
+  }
   roots.sort((a, b) => a.firstOrder - b.firstOrder);
 
   const units: AssistantRenderUnit[] = [

--- a/packages/chatkit-ui/src/lib/agent-runs.ts
+++ b/packages/chatkit-ui/src/lib/agent-runs.ts
@@ -80,9 +80,17 @@ function readTrimmedString(value: unknown): string | null {
 }
 
 function readOptionalNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value)
-    ? value
-    : undefined;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (typeof value !== 'string') return undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const numberValue = Number(trimmed);
+  return Number.isFinite(numberValue) ? numberValue : undefined;
 }
 
 function readNestedName(value: unknown): string | undefined {

--- a/packages/chatkit-ui/src/providers/Stream.test.ts
+++ b/packages/chatkit-ui/src/providers/Stream.test.ts
@@ -84,6 +84,28 @@ describe('conversation message history pagination', () => {
     expect(page.hasMore).toBe(false);
   });
 
+  it('preserves persisted assistant message status', () => {
+    const page = normalizeConversationMessagesPage({
+      items: [
+        {
+          id: 'assistant-1',
+          role: 'ai',
+          content: 'Done',
+          status: 'success',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ] as any,
+    });
+
+    expect(page.messages[0]).toEqual(
+      expect.objectContaining({
+        id: 'assistant-1',
+        type: 'ai',
+        status: 'success',
+      }),
+    );
+  });
+
   it('prepends older pages in order while preserving existing duplicates', () => {
     const merged = mergeHistoryUiMessages(
       [
@@ -616,7 +638,7 @@ describe('applyStreamEvent', () => {
             agentKey: 'Agent_A',
             title: 'Researcher',
             status: 'success',
-            elapsedTime: 1234,
+            elapsedTime: '1234',
           },
         }),
       },

--- a/packages/chatkit-ui/src/providers/Stream.tsx
+++ b/packages/chatkit-ui/src/providers/Stream.tsx
@@ -150,6 +150,7 @@ export {
 export type { PendingHITLRequest } from '../lib/hitl';
 
 type ChatKitAIMessage = Message & {
+  status?: string;
   executionId?: string;
   createdAt?: string;
   updatedAt?: string;
@@ -628,6 +629,7 @@ function mapChatMessageToUiMessage(
     id: message.id ?? createMessageId(),
     type,
     content,
+    ...(typeof message.status === 'string' ? { status: message.status } : {}),
     ...(message.reasoning ? { reasoning: message.reasoning as any } : {}),
     ...(message.executionId ? { executionId: message.executionId } : {}),
     ...(message.createdAt ? { createdAt: message.createdAt } : {}),


### PR DESCRIPTION
## Summary

Fix ChatKit agent run rendering when persisted conversation history is loaded after a page refresh.

The visible issue was that completed sub-agent groups could appear as pending/running after refresh, and agent run headers could show `0ms` even while the underlying run had meaningful timing data.

## Root Cause

Persisted assistant messages carried a `status` from the backend, but ChatKit's history mapping dropped that field when converting stored messages into UI messages. The agent run render tree then had no completed parent message status to use when reconstructing grouped agent nodes from historical content.

Agent run durations had two related issues: persisted `elapsedTime` values may arrive as numeric strings from the API and were ignored by the UI normalizer, and running agent rows used static `createdAt`/`updatedAt` timestamps, which often produced `0ms` because those timestamps can be equal at run start.

## Changes

- Preserve persisted assistant message `status` when normalizing conversation history.
- Mark incomplete grouped agent nodes successful when their saved parent assistant message completed.
- Normalize numeric-string `elapsedTime` values for agent runs.
- Update running agent run durations from the start timestamp to the current time, with a guard to avoid starting timers when no start timestamp exists.
- Add focused regression coverage for history status restoration, completed grouped agent nodes, numeric-string durations, and running duration updates.
- Add a patch changeset for `@xpert-ai/chatkit-ui`.

## Validation

- `pnpm exec vitest run src/providers/Stream.test.ts src/lib/agent-run-render-tree.test.ts src/components/thread/messages/ai.test.tsx --passWithNoTests`
- `pnpm --filter @xpert-ai/chatkit-ui build`
- `git diff --check`