### PR TITLE
feat: add Vue 2 ChatKit bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ chatkit-js/
 │   ├── chatkit-js/           # Vanilla JS integration helpers
 │   ├── chatkit-react/        # React bindings
 │   ├── chatkit-vue/          # Vue bindings
+│   ├── chatkit-vue2/         # Vue 2 bindings
 │   ├── chatkit-angular/      # Angular bindings
 │   ├── chatkit-ui5/          # SAP UI5 bindings
 │   ├── chatkit-ui/           # Iframe chat UI application
@@ -101,6 +102,7 @@ chatkit-js/
 - [@xpert-ai/chatkit-js](./packages/chatkit-js/)
 - [@xpert-ai/chatkit-react](./packages/chatkit-react/)
 - [@xpert-ai/chatkit-vue](./packages/chatkit-vue/)
+- [@xpert-ai/chatkit-vue2](./packages/chatkit-vue2/)
 - [@xpert-ai/chatkit-angular](./packages/chatkit-angular/)
 - [@xpert-ai/chatkit-ui5](./packages/chatkit-ui5/)
 - [@xpert-ai/chatkit-ui](./packages/chatkit-ui/)

--- a/packages/chatkit-vue2/CHANGELOG.md
+++ b/packages/chatkit-vue2/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @xpert-ai/chatkit-vue2
+
+## 0.3.0
+
+### Minor Changes
+
+- Add Vue 2 bindings for the Xpert ChatKit web component.

--- a/packages/chatkit-vue2/README.md
+++ b/packages/chatkit-vue2/README.md
@@ -1,0 +1,87 @@
+# @xpert-ai/chatkit-vue2
+
+Vue 2 bindings for the Xpert ChatKit web component.
+
+## Install
+
+```bash
+pnpm add @xpert-ai/chatkit-vue2 vue@^2.7
+```
+
+## Usage
+
+Register the ChatKit custom element as ignored in your Vue 2 app entry:
+
+```ts
+import Vue from 'vue';
+
+Vue.config.ignoredElements = [...Vue.config.ignoredElements, 'xpertai-chatkit'];
+```
+
+Then create a ChatKit control and pass it to the wrapper component:
+
+```vue
+<template>
+  <ChatKit :control="chatkit" style="height: 100vh;" />
+</template>
+
+<script>
+import { ChatKit, createChatKit } from '@xpert-ai/chatkit-vue2';
+
+export default {
+  components: { ChatKit },
+  data() {
+    return {
+      chatkit: createChatKit({
+        frameUrl: '<url-to-chatkit-frame>',
+        api: {
+          apiUrl: 'https://api.xpertai.cn',
+          xpertId: 'your-assistant-id',
+          getClientSecret: async () => {
+            const response = await fetch('/api/create-session', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+            });
+            const data = await response.json();
+
+            return {
+              secret: data.client_secret,
+              organizationId: data.organization_id,
+            };
+          },
+        },
+        onReady: () => {
+          console.log('ChatKit is ready');
+        },
+      }),
+    };
+  },
+};
+</script>
+```
+
+`getClientSecret` may continue returning the legacy `string`, or return
+`{ secret, organizationId }` to have ChatKit send `organization-id` on hosted
+API requests.
+
+## Updating Options
+
+`createChatKit` returns a control object that stores options and exposes the web
+component methods:
+
+```js
+this.chatkit.setOptions({
+  frameUrl: '<url-to-chatkit-frame>',
+  api: {
+    /* ... */
+  },
+  onReady: () => {},
+});
+
+this.chatkit.focusComposer();
+this.chatkit.setThreadId('thread-id');
+this.chatkit.sendUserMessage({ text: 'Hello' });
+```
+
+Options are replaced, not merged. Pass the full option object whenever you call
+`setOptions`.

--- a/packages/chatkit-vue2/package.json
+++ b/packages/chatkit-vue2/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@xpert-ai/chatkit-vue2",
+  "version": "0.3.0",
+  "description": "Vue 2 bindings for Xpert Chatkit",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "type-check": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "vue": ">=2.6 <3"
+  },
+  "dependencies": {
+    "@xpert-ai/chatkit-types": "workspace:~",
+    "@xpert-ai/chatkit-web-component": "workspace:~"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0",
+    "vite-plugin-dts": "^3.7.0",
+    "vue": "2.7.16"
+  },
+  "keywords": [
+    "chatkit",
+    "vue",
+    "vue2",
+    "xpert"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "directory": "packages/chatkit-vue2",
+    "type": "git",
+    "url": "https://github.com/xpert-ai/chatkit-js"
+  }
+}

--- a/packages/chatkit-vue2/src/chatkit.ts
+++ b/packages/chatkit-vue2/src/chatkit.ts
@@ -1,0 +1,211 @@
+import Vue from 'vue';
+import type { CreateElement, VNode } from 'vue';
+import type {
+  ChatKitEvents,
+  ChatKitOptions,
+  XpertAIChatKit,
+} from '@xpert-ai/chatkit-types';
+import '@xpert-ai/chatkit-web-component';
+import type {
+  ChatKitControl,
+  ChatKitEventHandlers,
+  InternalChatKitControl,
+  ToEventHandlerKey,
+} from './control.js';
+
+type ListenerCleanup = (() => void) | undefined;
+
+const EVENT_HANDLER_MAP: {
+  [K in keyof ChatKitEvents]: ToEventHandlerKey<K>;
+} = {
+  'chatkit.error': 'onError',
+  'chatkit.response.end': 'onResponseEnd',
+  'chatkit.response.start': 'onResponseStart',
+  'chatkit.log': 'onLog',
+  'chatkit.thread.change': 'onThreadChange',
+  'chatkit.thread.load.start': 'onThreadLoadStart',
+  'chatkit.thread.load.end': 'onThreadLoadEnd',
+  'chatkit.ready': 'onReady',
+  'chatkit.effect': 'onEffect',
+};
+
+const EVENT_NAMES = Object.keys(EVENT_HANDLER_MAP) as (keyof ChatKitEvents)[];
+
+type ChatKitComponentInstance = Vue & {
+  control: ChatKitControl;
+  currentControl: InternalChatKitControl | null;
+  optionsCleanup: ListenerCleanup;
+  handlersCleanup: ListenerCleanup;
+  controlCleanup: (() => void) | null;
+  bindControl: (control: ChatKitControl | null) => void;
+  syncControl: () => void;
+  unbindCurrentControl: () => void;
+};
+
+function applyOptions(
+  element: XpertAIChatKit,
+  options: ChatKitOptions,
+  isCurrent: () => boolean,
+): ListenerCleanup {
+  if (typeof customElements === 'undefined') {
+    if (typeof element.setOptions === 'function') {
+      element.setOptions(options);
+    }
+    return undefined;
+  }
+
+  if (customElements.get('xpertai-chatkit')) {
+    element.setOptions(options);
+    return undefined;
+  }
+
+  let active = true;
+  customElements.whenDefined('xpertai-chatkit').then(() => {
+    if (active && isCurrent()) {
+      element.setOptions(options);
+    }
+  });
+
+  return () => {
+    active = false;
+  };
+}
+
+function bindEventHandlers(
+  element: XpertAIChatKit,
+  handlers: ChatKitEventHandlers,
+): ListenerCleanup {
+  const cleanups: Array<() => void> = [];
+
+  for (const eventName of EVENT_NAMES) {
+    const listener = (event: Event) => {
+      const handlerName = EVENT_HANDLER_MAP[eventName];
+      const handler = handlers[handlerName];
+      if (typeof handler === 'function') {
+        handler((event as CustomEvent).detail as never);
+      }
+    };
+
+    element.addEventListener(eventName, listener);
+    cleanups.push(() => {
+      element.removeEventListener(eventName, listener);
+    });
+  }
+
+  return () => {
+    for (const cleanup of cleanups) {
+      cleanup();
+    }
+  };
+}
+
+export const ChatKit = Vue.extend({
+  name: 'ChatKit',
+  inheritAttrs: false,
+  props: {
+    control: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      currentControl: null as InternalChatKitControl | null,
+      optionsCleanup: undefined as ListenerCleanup,
+      handlersCleanup: undefined as ListenerCleanup,
+      controlCleanup: null as (() => void) | null,
+    };
+  },
+  watch: {
+    control(this: ChatKitComponentInstance, value: ChatKitControl | null) {
+      this.bindControl(value);
+    },
+  },
+  mounted(this: ChatKitComponentInstance) {
+    this.bindControl(this.control);
+  },
+  beforeDestroy(this: ChatKitComponentInstance) {
+    this.unbindCurrentControl();
+  },
+  methods: {
+    bindControl(
+      this: ChatKitComponentInstance,
+      control: ChatKitControl | null,
+    ): void {
+      if (!control) {
+        this.unbindCurrentControl();
+        return;
+      }
+
+      const nextControl = control as InternalChatKitControl;
+      if (nextControl === this.currentControl) {
+        return;
+      }
+
+      this.unbindCurrentControl();
+      this.currentControl = nextControl;
+      this.controlCleanup = nextControl.subscribe(() => {
+        this.syncControl();
+      });
+      this.syncControl();
+    },
+
+    syncControl(this: ChatKitComponentInstance): void {
+      const control = this.currentControl;
+      const element = this.$refs.chatkit as XpertAIChatKit | undefined;
+
+      if (!control || !element) {
+        return;
+      }
+
+      control.setInstance(element);
+
+      if (this.optionsCleanup) {
+        this.optionsCleanup();
+        this.optionsCleanup = undefined;
+      }
+
+      this.optionsCleanup = applyOptions(element, control.getOptions(), () => {
+        return (
+          this.currentControl === control && this.$refs.chatkit === element
+        );
+      });
+
+      if (this.handlersCleanup) {
+        this.handlersCleanup();
+        this.handlersCleanup = undefined;
+      }
+
+      this.handlersCleanup = bindEventHandlers(element, control.getHandlers());
+    },
+
+    unbindCurrentControl(this: ChatKitComponentInstance): void {
+      if (this.optionsCleanup) {
+        this.optionsCleanup();
+        this.optionsCleanup = undefined;
+      }
+
+      if (this.handlersCleanup) {
+        this.handlersCleanup();
+        this.handlersCleanup = undefined;
+      }
+
+      if (this.controlCleanup) {
+        this.controlCleanup();
+        this.controlCleanup = null;
+      }
+
+      if (this.currentControl) {
+        this.currentControl.setInstance(null);
+        this.currentControl = null;
+      }
+    },
+  },
+  render(this: ChatKitComponentInstance, h: CreateElement): VNode {
+    return h('xpertai-chatkit', {
+      ref: 'chatkit',
+      attrs: this.$attrs,
+      on: this.$listeners,
+    });
+  },
+});

--- a/packages/chatkit-vue2/src/control.ts
+++ b/packages/chatkit-vue2/src/control.ts
@@ -1,0 +1,179 @@
+import type {
+  ChatKitEvents,
+  ChatKitOptions,
+  XpertAIChatKit,
+} from '@xpert-ai/chatkit-types';
+
+type DotToCamelCase<S extends string> = S extends `${infer Head}.${infer Tail}`
+  ? `${Head}${Capitalize<DotToCamelCase<Tail>>}`
+  : S;
+
+const CHATKIT_METHOD_NAMES = Object.freeze([
+  'focusComposer',
+  'setThreadId',
+  'sendUserMessage',
+  'setComposerValue',
+  'fetchUpdates',
+  'sendCustomAction',
+] as const);
+
+type ChatKitMethod = (typeof CHATKIT_METHOD_NAMES)[number];
+
+type ChatKitMethods = {
+  [K in ChatKitMethod]: XpertAIChatKit[K];
+};
+
+type ControlListener = () => void;
+
+const EXCLUDED_HANDLER_KEYS = new Set(['onClientTool']);
+
+export type ToEventHandlerKey<K extends keyof ChatKitEvents> = K extends string
+  ? DotToCamelCase<K> extends `chatkit${infer EventName}`
+    ? `on${Capitalize<EventName>}`
+    : never
+  : never;
+
+export type ChatKitEventHandlers = Partial<{
+  [K in keyof ChatKitEvents as ToEventHandlerKey<K>]: ChatKitEvents[K] extends CustomEvent<
+    infer Detail
+  >
+    ? Detail extends undefined
+      ? () => void
+      : (event: Detail) => void
+    : never;
+}>;
+
+export type CreateChatKitOptions = ChatKitOptions & ChatKitEventHandlers;
+
+export type ChatKitControl = ChatKitMethods & {
+  readonly element: XpertAIChatKit | null;
+  setOptions: (next: CreateChatKitOptions) => void;
+};
+
+export type InternalChatKitControl = ChatKitControl & {
+  setInstance: (instance: XpertAIChatKit | null) => void;
+  subscribe: (listener: ControlListener) => () => void;
+  getOptions: () => ChatKitOptions;
+  getHandlers: () => ChatKitEventHandlers;
+};
+
+function splitOptions(value: CreateChatKitOptions | undefined): {
+  options: ChatKitOptions;
+  handlers: ChatKitEventHandlers;
+} {
+  const options = {} as ChatKitOptions;
+  const handlers: ChatKitEventHandlers = {};
+
+  if (!value) {
+    return { options, handlers };
+  }
+
+  for (const [key, entry] of Object.entries(value)) {
+    if (/^on[A-Z]/.test(key) && !EXCLUDED_HANDLER_KEYS.has(key)) {
+      if (typeof entry === 'function') {
+        Object.assign(handlers, { [key]: entry });
+      }
+    } else {
+      Object.assign(options, { [key]: entry });
+    }
+  }
+
+  return { options, handlers };
+}
+
+function warnUnmounted(): void {
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn('ChatKit element is not mounted');
+  }
+}
+
+class ChatKitController {
+  private instance: XpertAIChatKit | null = null;
+  private options: ChatKitOptions = {} as ChatKitOptions;
+  private handlers: ChatKitEventHandlers = {};
+  private readonly listeners = new Set<ControlListener>();
+
+  constructor(initialOptions: CreateChatKitOptions) {
+    this.setOptions(initialOptions);
+  }
+
+  get element(): XpertAIChatKit | null {
+    return this.instance;
+  }
+
+  setOptions(next: CreateChatKitOptions): void {
+    const state = splitOptions(next);
+    this.options = state.options;
+    this.handlers = state.handlers;
+    this.emit();
+  }
+
+  setInstance(instance: XpertAIChatKit | null): void {
+    this.instance = instance;
+  }
+
+  subscribe(listener: ControlListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getOptions(): ChatKitOptions {
+    return this.options;
+  }
+
+  getHandlers(): ChatKitEventHandlers {
+    return this.handlers;
+  }
+
+  focusComposer(...args: Parameters<XpertAIChatKit['focusComposer']>) {
+    return this.callMethod('focusComposer', ...args);
+  }
+
+  setThreadId(...args: Parameters<XpertAIChatKit['setThreadId']>) {
+    return this.callMethod('setThreadId', ...args);
+  }
+
+  sendUserMessage(...args: Parameters<XpertAIChatKit['sendUserMessage']>) {
+    return this.callMethod('sendUserMessage', ...args);
+  }
+
+  setComposerValue(...args: Parameters<XpertAIChatKit['setComposerValue']>) {
+    return this.callMethod('setComposerValue', ...args);
+  }
+
+  fetchUpdates(...args: Parameters<XpertAIChatKit['fetchUpdates']>) {
+    return this.callMethod('fetchUpdates', ...args);
+  }
+
+  sendCustomAction(...args: Parameters<XpertAIChatKit['sendCustomAction']>) {
+    return this.callMethod('sendCustomAction', ...args);
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+
+  private callMethod<K extends ChatKitMethod>(
+    method: K,
+    ...args: Parameters<ChatKitMethods[K]>
+  ): ReturnType<ChatKitMethods[K]> | undefined {
+    const methodRef = this.instance?.[method];
+    if (!this.instance || typeof methodRef !== 'function') {
+      warnUnmounted();
+      return undefined;
+    }
+
+    return (methodRef as (...args: unknown[]) => unknown).apply(
+      this.instance,
+      args,
+    ) as ReturnType<ChatKitMethods[K]>;
+  }
+}
+
+export function createChatKit(options: CreateChatKitOptions): ChatKitControl {
+  return new ChatKitController(options) as ChatKitControl;
+}

--- a/packages/chatkit-vue2/src/index.ts
+++ b/packages/chatkit-vue2/src/index.ts
@@ -1,0 +1,8 @@
+export { ChatKit } from './chatkit.js';
+export {
+  createChatKit,
+  type ChatKitControl,
+  type ChatKitEventHandlers,
+  type CreateChatKitOptions,
+  type ToEventHandlerKey,
+} from './control.js';

--- a/packages/chatkit-vue2/tsconfig.json
+++ b/packages/chatkit-vue2/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/chatkit-vue2/vite.config.ts
+++ b/packages/chatkit-vue2/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+import { resolve } from 'path';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths(), dts({ rollupTypes: true })],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      name: 'XpertChatkitVue2',
+      fileName: 'index',
+      formats: ['es'],
+    },
+    rollupOptions: {
+      external: ['vue', '@xpert-ai/chatkit-types'],
+      output: {
+        globals: {
+          vue: 'Vue',
+        },
+      },
+    },
+    sourcemap: true,
+    minify: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,6 +560,28 @@ importers:
         specifier: ^3.7.0
         version: 3.9.1(@types/node@20.19.27)(rollup@4.53.5)(typescript@5.9.3)(vite@5.4.21(@types/node@20.19.27)(less@4.6.4)(lightningcss@1.30.2)(sass@1.98.0))
 
+  packages/chatkit-vue2:
+    dependencies:
+      '@xpert-ai/chatkit-types':
+        specifier: workspace:~
+        version: link:../chatkit
+      '@xpert-ai/chatkit-web-component':
+        specifier: workspace:~
+        version: link:../web-component
+    devDependencies:
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@20.19.27)(less@4.6.4)(lightningcss@1.30.2)(sass@1.98.0)
+      vite-plugin-dts:
+        specifier: ^3.7.0
+        version: 3.9.1(@types/node@20.19.27)(rollup@4.53.5)(typescript@5.9.3)(vite@5.4.21(@types/node@20.19.27)(less@4.6.4)(lightningcss@1.30.2)(sass@1.98.0))
+      vue:
+        specifier: 2.7.16
+        version: 2.7.16
+
   packages/chatkit-web-shared:
     dependencies:
       '@microsoft/fetch-event-source':
@@ -3499,6 +3521,9 @@ packages:
 
   '@vue/compiler-dom@3.5.26':
     resolution: {integrity: sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==}
+
+  '@vue/compiler-sfc@2.7.16':
+    resolution: {integrity: sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==}
 
   '@vue/compiler-sfc@3.5.26':
     resolution: {integrity: sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==}
@@ -7495,6 +7520,10 @@ packages:
     peerDependencies:
       typescript: '*'
 
+  vue@2.7.16:
+    resolution: {integrity: sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==}
+    deprecated: Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.
+
   vue@3.5.26:
     resolution: {integrity: sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==}
     peerDependencies:
@@ -10387,6 +10416,14 @@ snapshots:
     dependencies:
       '@vue/compiler-core': 3.5.26
       '@vue/shared': 3.5.26
+
+  '@vue/compiler-sfc@2.7.16':
+    dependencies:
+      '@babel/parser': 7.28.5
+      postcss: 8.5.6
+      source-map: 0.6.1
+    optionalDependencies:
+      prettier: 2.8.8
 
   '@vue/compiler-sfc@3.5.26':
     dependencies:
@@ -15065,6 +15102,11 @@ snapshots:
       '@vue/language-core': 1.8.27(typescript@5.9.3)
       semver: 7.7.3
       typescript: 5.9.3
+
+  vue@2.7.16:
+    dependencies:
+      '@vue/compiler-sfc': 2.7.16
+      csstype: 3.2.3
 
   vue@3.5.26(typescript@5.9.3):
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,6 +23,7 @@
       "@xpert-ai/chatkit-react": ["packages/chatkit-react/src/index.ts"],
       "@xpert-ai/chatkit-types": ["packages/chatkit/src/index.ts"],
       "@xpert-ai/chatkit-vue": ["packages/chatkit-vue/src/index.ts"],
+      "@xpert-ai/chatkit-vue2": ["packages/chatkit-vue2/src/index.ts"],
       "@xpert-ai/chatkit-web-component": [
         "packages/web-component/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

Adds a new `@xpert-ai/chatkit-vue2` package for Vue 2 applications, following the existing ChatKit framework binding pattern while keeping the package scoped to Vue 2.

The package exposes a `ChatKit` Vue component and `createChatKit` control helper. The control stores ChatKit options, separates event handlers from web component options, forwards supported ChatKit web component methods, and keeps the mounted web component instance in sync with Vue 2 lifecycle updates.

Root package documentation and TypeScript path mappings are updated so the new package is discoverable in the monorepo. The lockfile update is limited to the new Vue 2 package importer plus the required Vue 2 dependency entries.

No changeset is included because this is a new package with its initial `0.3.0` version and matching changelog entry; adding a changeset would bump the initial version again.

## Validation

- `pnpm --filter @xpert-ai/chatkit-vue2 type-check`
- `pnpm --filter @xpert-ai/chatkit-vue2 build`
- `git diff --check`
- `pnpm install --frozen-lockfile --lockfile-only`

Note: the build prints the existing API Extractor warning that the bundled TypeScript version is older than the project TypeScript version, but the build completes successfully.