### PR TITLE
feat: preserve thread goal specs

### DIFF
--- a/.changeset/clean-goal-specs.md
+++ b/.changeset/clean-goal-specs.md
@@ -1,0 +1,6 @@
+---
+"@xpert-ai/chatkit-types": patch
+"@xpert-ai/chatkit-ui": patch
+---
+
+Preserve thread goal specs in parsed goal payloads.

--- a/packages/chatkit-ui/src/lib/thread-goals.test.ts
+++ b/packages/chatkit-ui/src/lib/thread-goals.test.ts
@@ -137,6 +137,36 @@ describe('thread goals', () => {
     ).not.toHaveProperty(removedBudgetField);
   });
 
+  it('preserves optional goal specs from parsed goal payloads', () => {
+    expect(
+      parseThreadGoal({
+        id: 'goal-1',
+        conversationId: 'conversation-1',
+        threadId: 'thread-1',
+        objective: 'ship feature',
+        status: 'active',
+        tokensUsed: 0,
+        elapsedSeconds: 0,
+        continuationCount: 0,
+        goalSpec: {
+          originalObjective: 'ship feature',
+          executableGoal: 'Work toward this goal: ship feature',
+          successCriteria: ['The feature is shipped.'],
+          constraints: ['Do not change unrelated behavior.'],
+          verificationChecklist: ['Verify the feature is shipped.'],
+          recommendedStrategy: 'act_then_verify',
+          source: 'system',
+          generatedAt: '2026-06-11T00:00:00.000Z',
+        },
+      }),
+    ).toMatchObject({
+      goalSpec: {
+        originalObjective: 'ship feature',
+        executableGoal: 'Work toward this goal: ship feature',
+      },
+    });
+  });
+
   it('maps goal commands to a host goal adapter', async () => {
     const adapter = goalFixture();
 

--- a/packages/chatkit-ui/src/lib/thread-goals.ts
+++ b/packages/chatkit-ui/src/lib/thread-goals.ts
@@ -1,6 +1,7 @@
 import type {
   ChatKitGoalAdapter,
   ThreadGoal,
+  ThreadGoalSpec,
   ThreadGoalStatus,
   TThreadGoalClearedEvent,
   TThreadGoalUpdatedEvent,
@@ -178,6 +179,48 @@ function normalizeNumber(value: unknown): number {
   return 0;
 }
 
+function parseStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    return null;
+  }
+  return value;
+}
+
+function parseThreadGoalSpec(value: unknown): ThreadGoalSpec | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const raw = value as Partial<ThreadGoalSpec>;
+  const successCriteria = parseStringArray(raw.successCriteria);
+  const constraints = parseStringArray(raw.constraints);
+  const verificationChecklist = parseStringArray(raw.verificationChecklist);
+
+  if (
+    typeof raw.originalObjective !== 'string' ||
+    typeof raw.executableGoal !== 'string' ||
+    !successCriteria ||
+    !constraints ||
+    !verificationChecklist ||
+    typeof raw.recommendedStrategy !== 'string' ||
+    (raw.source !== 'system' && raw.source !== 'llm') ||
+    typeof raw.generatedAt !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    originalObjective: raw.originalObjective,
+    executableGoal: raw.executableGoal,
+    successCriteria,
+    constraints,
+    verificationChecklist,
+    recommendedStrategy: raw.recommendedStrategy,
+    source: raw.source,
+    generatedAt: raw.generatedAt,
+  };
+}
+
 export function parseThreadGoal(value: unknown): ThreadGoal | null {
   if (!value || typeof value !== 'object') {
     return null;
@@ -199,6 +242,12 @@ export function parseThreadGoal(value: unknown): ThreadGoal | null {
     threadId: raw.threadId,
     objective: raw.objective,
     status: raw.status,
+    ...(raw.goalSpec === null
+      ? { goalSpec: null }
+      : (() => {
+          const goalSpec = parseThreadGoalSpec(raw.goalSpec);
+          return goalSpec ? { goalSpec } : {};
+        })()),
     tokensUsed: normalizeNumber(raw.tokensUsed),
     elapsedSeconds: normalizeNumber(raw.elapsedSeconds),
     continuationCount: normalizeNumber(raw.continuationCount),
@@ -263,6 +312,12 @@ export function parseThreadGoalUpdatedPatchEvent(
     ...(typeof goal.objective === 'string'
       ? { objective: goal.objective }
       : {}),
+    ...(goal.goalSpec === null
+      ? { goalSpec: null }
+      : (() => {
+          const goalSpec = parseThreadGoalSpec(goal.goalSpec);
+          return goalSpec ? { goalSpec } : {};
+        })()),
     ...(typeof goal.tokensUsed === 'number'
       ? { tokensUsed: normalizeNumber(goal.tokensUsed) }
       : {}),

--- a/packages/chatkit/src/message.ts
+++ b/packages/chatkit/src/message.ts
@@ -384,12 +384,24 @@ export type ThreadGoalStatus =
   | 'budget_limited'
   | 'complete';
 
+export type ThreadGoalSpec = {
+  originalObjective: string;
+  executableGoal: string;
+  successCriteria: string[];
+  constraints: string[];
+  verificationChecklist: string[];
+  recommendedStrategy: string;
+  source: 'system' | 'llm';
+  generatedAt: string;
+};
+
 export type ThreadGoal = {
   id?: string;
   conversationId?: string;
   threadId: string;
   objective: string;
   status: ThreadGoalStatus;
+  goalSpec?: ThreadGoalSpec | null;
   tokensUsed: number;
   elapsedSeconds: number;
   continuationCount: number;


### PR DESCRIPTION
## Summary

- Add public `ThreadGoalSpec` typing for goal metadata.
- Preserve optional `goalSpec` when parsing thread goal payloads in chatkit UI.
- Add coverage for valid goal specs and invalid goal spec payloads.
- Add a changeset for the chatkit type/UI package update.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm test -- --run packages/chatkit-ui/src/lib/thread-goals.test.ts`
- `pnpm build`
- `git diff --check`

## Notes

- This PR targets `main` and was prepared in a clean worktree from `origin/main`.