### PR TITLE
fix: defer context usage loading

### DIFF
--- a/.changeset/defer-context-usage-loading.md
+++ b/.changeset/defer-context-usage-loading.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/chatkit-ui': patch
+---
+
+Defer context usage loading until the ChatKit client secret is available.

--- a/packages/chatkit-ui/src/App.test.tsx
+++ b/packages/chatkit-ui/src/App.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ChatKitOptions } from '@xpert-ai/chatkit-types';
+
+import App from './App';
+import { Chat } from './components/chat';
+import { StreamProvider } from './providers/Stream';
+
+vi.mock('@xpert-ai/a2ui-react', () => ({
+  A2UIProvider: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock('./components/chat', () => ({
+  Chat: vi.fn(() => <div data-testid="chat" />),
+}));
+
+vi.mock('./providers/Stream', () => ({
+  StreamProvider: vi.fn(({ children }: { children: React.ReactNode }) => (
+    <div data-testid="stream-provider">{children}</div>
+  )),
+}));
+
+vi.mock('./providers/Theme', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock('./hooks/useParentMessenger', () => ({
+  useParentMessenger: () => ({
+    isParentAvailable: false,
+    sendCommand: vi.fn(),
+  }),
+}));
+
+vi.mock('./i18n', () => ({
+  getLanguage: () => 'en',
+  setLanguage: vi.fn(),
+}));
+
+const options = {
+  api: {
+    apiUrl: '/api/ai',
+    xpertId: 'xpert-1',
+    getClientSecret: async () => 'secret',
+  },
+} satisfies ChatKitOptions;
+
+describe('App', () => {
+  it('renders the chat shell while the parent client secret is initializing', () => {
+    render(
+      <App clientSecret="" options={options} isClientSecretInitializing />,
+    );
+
+    expect(screen.getByTestId('stream-provider')).toBeInTheDocument();
+    expect(screen.getByTestId('chat')).toBeInTheDocument();
+    expect(StreamProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: undefined,
+        apiUrl: '/api/ai',
+        xpertId: 'xpert-1',
+      }),
+      undefined,
+    );
+    expect(Chat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientSecret: undefined,
+        isClientSecretInitializing: true,
+      }),
+      undefined,
+    );
+  });
+
+  it('mounts the StreamProvider once a client secret is available', () => {
+    render(
+      <App
+        clientSecret="secret"
+        organizationId="org-1"
+        options={options}
+        isClientSecretInitializing
+      />,
+    );
+
+    expect(screen.getByTestId('stream-provider')).toBeInTheDocument();
+    expect(screen.getByTestId('chat')).toBeInTheDocument();
+    expect(StreamProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'secret',
+        organizationId: 'org-1',
+        apiUrl: '/api/ai',
+        xpertId: 'xpert-1',
+      }),
+      undefined,
+    );
+  });
+});

--- a/packages/chatkit-ui/src/components/thread/context-usage-indicator.test.tsx
+++ b/packages/chatkit-ui/src/components/thread/context-usage-indicator.test.tsx
@@ -1,0 +1,91 @@
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ContextUsageIndicator } from './context-usage-indicator';
+import { useStreamContext } from '../../providers/Stream';
+
+vi.mock('../../providers/Stream', () => ({
+  useStreamContext: vi.fn(),
+}));
+
+vi.mock('../../i18n/useChatkitTranslation', () => ({
+  useChatkitTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../ui/progress-circle', () => ({
+  ProgressCircle: () => <div data-testid="progress-circle" />,
+}));
+
+vi.mock('../ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+const mockUseStreamContext = vi.mocked(useStreamContext);
+
+function createStream(overrides: Record<string, unknown> = {}) {
+  return {
+    apiKey: 'secret',
+    apiUrl: '/api/ai',
+    assistantId: 'assistant-1',
+    client: {
+      assistants: {
+        get: vi.fn().mockResolvedValue({
+          metadata: {
+            context_size: 1000,
+            agent_key: 'agent-1',
+          },
+        }),
+      },
+      threads: {
+        getContextUsage: vi.fn().mockResolvedValue({
+          usage: {
+            context_tokens: 100,
+          },
+        }),
+      },
+    },
+    contextUsageByAgentKey: {},
+    threadId: null,
+    isLoading: false,
+    ...overrides,
+  };
+}
+
+describe('ContextUsageIndicator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not load assistant context size before the client secret is ready', () => {
+    const stream = createStream({ apiKey: '' });
+    mockUseStreamContext.mockReturnValue(
+      stream as ReturnType<typeof useStreamContext>,
+    );
+
+    render(<ContextUsageIndicator />);
+
+    expect(stream.client.assistants.get).not.toHaveBeenCalled();
+    expect(stream.client.threads.getContextUsage).not.toHaveBeenCalled();
+  });
+
+  it('loads assistant context size once API configuration is available', async () => {
+    const stream = createStream();
+    mockUseStreamContext.mockReturnValue(
+      stream as ReturnType<typeof useStreamContext>,
+    );
+
+    render(<ContextUsageIndicator />);
+
+    await waitFor(() => {
+      expect(stream.client.assistants.get).toHaveBeenCalledWith('assistant-1');
+    });
+  });
+});

--- a/packages/chatkit-ui/src/components/thread/context-usage-indicator.tsx
+++ b/packages/chatkit-ui/src/components/thread/context-usage-indicator.tsx
@@ -67,9 +67,15 @@ export function ContextUsageIndicator({
 }: ContextUsageIndicatorProps) {
   const { t } = useChatkitTranslation();
   const stream = useStreamContext();
-  const [maxContextSize, setMaxContextSize] = React.useState<number | null>(null);
-  const [usedContextSize, setUsedContextSize] = React.useState<number | null>(null);
-  const [assistantAgentKey, setAssistantAgentKey] = React.useState<string | null>(null);
+  const [maxContextSize, setMaxContextSize] = React.useState<number | null>(
+    null,
+  );
+  const [usedContextSize, setUsedContextSize] = React.useState<number | null>(
+    null,
+  );
+  const [assistantAgentKey, setAssistantAgentKey] = React.useState<
+    string | null
+  >(null);
   const latestRealtimeUsageRef = React.useRef<{
     threadId: string | null;
     agentKey: string | null;
@@ -81,13 +87,18 @@ export function ContextUsageIndicator({
   });
 
   const realtimeUsage = React.useMemo(
-    () => getThreadContextUsage(stream.contextUsageByAgentKey, assistantAgentKey),
+    () =>
+      getThreadContextUsage(stream.contextUsageByAgentKey, assistantAgentKey),
     [assistantAgentKey, stream.contextUsageByAgentKey],
   );
-  const realtimeUsedContextSize = getThreadContextUsageTotalTokens(realtimeUsage);
+  const realtimeUsedContextSize =
+    getThreadContextUsageTotalTokens(realtimeUsage);
+  const hasApiConfiguration = Boolean(
+    stream.apiUrl?.trim() && stream.apiKey?.trim(),
+  );
 
   React.useEffect(() => {
-    if (!stream.client || !stream.assistantId) {
+    if (!hasApiConfiguration || !stream.client || !stream.assistantId) {
       setMaxContextSize(null);
       setAssistantAgentKey(null);
       return;
@@ -110,7 +121,7 @@ export function ContextUsageIndicator({
     return () => {
       cancelled = true;
     };
-  }, [stream.client, stream.assistantId]);
+  }, [hasApiConfiguration, stream.client, stream.assistantId]);
 
   React.useEffect(() => {
     latestRealtimeUsageRef.current = {
@@ -126,7 +137,7 @@ export function ContextUsageIndicator({
   }, [realtimeUsedContextSize]);
 
   React.useEffect(() => {
-    if (!stream.client) {
+    if (!hasApiConfiguration || !stream.client) {
       setUsedContextSize(null);
       return;
     }
@@ -140,11 +151,14 @@ export function ContextUsageIndicator({
     let cancelled = false;
     const requestThreadId = stream.threadId;
     const requestAgentKey = assistantAgentKey;
-    stream.client.threads.getContextUsage(
-            requestThreadId,
-            requestAgentKey ? { agentKey: requestAgentKey } : undefined,
-          )
-      .then((result) => normalizeContextUsageNumber(result?.usage?.context_tokens))
+    stream.client.threads
+      .getContextUsage(
+        requestThreadId,
+        requestAgentKey ? { agentKey: requestAgentKey } : undefined,
+      )
+      .then((result) =>
+        normalizeContextUsageNumber(result?.usage?.context_tokens),
+      )
       .then((result) => {
         if (cancelled) return;
         const latestRealtimeUsage = latestRealtimeUsageRef.current;
@@ -171,9 +185,8 @@ export function ContextUsageIndicator({
     };
   }, [
     assistantAgentKey,
+    hasApiConfiguration,
     realtimeUsedContextSize,
-    stream.apiKey,
-    stream.apiUrl,
     stream.client,
     stream.threadId,
     stream.isLoading,
@@ -203,9 +216,15 @@ export function ContextUsageIndicator({
     used: formattedUsed,
     max: formattedMax,
   });
-  const usageLabelWithSuffix = usageLabel.endsWith(':') ? usageLabel : `${usageLabel}:`;
+  const usageLabelWithSuffix = usageLabel.endsWith(':')
+    ? usageLabel
+    : `${usageLabel}:`;
   const progressClassName =
-    percent >= 90 ? 'text-destructive' : percent >= 75 ? 'text-amber-500' : 'text-primary dark:text-zinc-300';
+    percent >= 90
+      ? 'text-destructive'
+      : percent >= 75
+        ? 'text-amber-500'
+        : 'text-primary dark:text-zinc-300';
 
   return (
     <Tooltip>
@@ -218,12 +237,21 @@ export function ContextUsageIndicator({
           )}
           aria-label={`${usageLabelWithSuffix} ${usageFullLabel}. ${usageTokensLabel}`}
         >
-          <ProgressCircle value={percent} className={cn('size-3.5', progressClassName)} />
+          <ProgressCircle
+            value={percent}
+            className={cn('size-3.5', progressClassName)}
+          />
         </button>
       </TooltipTrigger>
-      <TooltipContent side="top" sideOffset={6} className="space-y-0.5 px-3 py-2 text-center">
+      <TooltipContent
+        side="top"
+        sideOffset={6}
+        className="space-y-0.5 px-3 py-2 text-center"
+      >
         <div className="text-primary-foreground/70">{usageLabelWithSuffix}</div>
-        <div className="font-medium text-primary-foreground/80">{usageFullLabel}</div>
+        <div className="font-medium text-primary-foreground/80">
+          {usageFullLabel}
+        </div>
         <div className="text-sm font-semibold">{usageTokensLabel}</div>
       </TooltipContent>
     </Tooltip>

--- a/packages/chatkit-ui/src/components/thread/context-usage-indicator.tsx
+++ b/packages/chatkit-ui/src/components/thread/context-usage-indicator.tsx
@@ -67,15 +67,9 @@ export function ContextUsageIndicator({
 }: ContextUsageIndicatorProps) {
   const { t } = useChatkitTranslation();
   const stream = useStreamContext();
-  const [maxContextSize, setMaxContextSize] = React.useState<number | null>(
-    null,
-  );
-  const [usedContextSize, setUsedContextSize] = React.useState<number | null>(
-    null,
-  );
-  const [assistantAgentKey, setAssistantAgentKey] = React.useState<
-    string | null
-  >(null);
+  const [maxContextSize, setMaxContextSize] = React.useState<number | null>(null);
+  const [usedContextSize, setUsedContextSize] = React.useState<number | null>(null);
+  const [assistantAgentKey, setAssistantAgentKey] = React.useState<string | null>(null);
   const latestRealtimeUsageRef = React.useRef<{
     threadId: string | null;
     agentKey: string | null;
@@ -87,15 +81,11 @@ export function ContextUsageIndicator({
   });
 
   const realtimeUsage = React.useMemo(
-    () =>
-      getThreadContextUsage(stream.contextUsageByAgentKey, assistantAgentKey),
+    () => getThreadContextUsage(stream.contextUsageByAgentKey, assistantAgentKey),
     [assistantAgentKey, stream.contextUsageByAgentKey],
   );
-  const realtimeUsedContextSize =
-    getThreadContextUsageTotalTokens(realtimeUsage);
-  const hasApiConfiguration = Boolean(
-    stream.apiUrl?.trim() && stream.apiKey?.trim(),
-  );
+  const realtimeUsedContextSize = getThreadContextUsageTotalTokens(realtimeUsage);
+  const hasApiConfiguration = Boolean(stream.apiUrl?.trim() && stream.apiKey?.trim());
 
   React.useEffect(() => {
     if (!hasApiConfiguration || !stream.client || !stream.assistantId) {
@@ -151,14 +141,11 @@ export function ContextUsageIndicator({
     let cancelled = false;
     const requestThreadId = stream.threadId;
     const requestAgentKey = assistantAgentKey;
-    stream.client.threads
-      .getContextUsage(
-        requestThreadId,
-        requestAgentKey ? { agentKey: requestAgentKey } : undefined,
-      )
-      .then((result) =>
-        normalizeContextUsageNumber(result?.usage?.context_tokens),
-      )
+    stream.client.threads.getContextUsage(
+            requestThreadId,
+            requestAgentKey ? { agentKey: requestAgentKey } : undefined,
+          )
+      .then((result) => normalizeContextUsageNumber(result?.usage?.context_tokens))
       .then((result) => {
         if (cancelled) return;
         const latestRealtimeUsage = latestRealtimeUsageRef.current;
@@ -187,6 +174,8 @@ export function ContextUsageIndicator({
     assistantAgentKey,
     hasApiConfiguration,
     realtimeUsedContextSize,
+    stream.apiKey,
+    stream.apiUrl,
     stream.client,
     stream.threadId,
     stream.isLoading,
@@ -216,15 +205,9 @@ export function ContextUsageIndicator({
     used: formattedUsed,
     max: formattedMax,
   });
-  const usageLabelWithSuffix = usageLabel.endsWith(':')
-    ? usageLabel
-    : `${usageLabel}:`;
+  const usageLabelWithSuffix = usageLabel.endsWith(':') ? usageLabel : `${usageLabel}:`;
   const progressClassName =
-    percent >= 90
-      ? 'text-destructive'
-      : percent >= 75
-        ? 'text-amber-500'
-        : 'text-primary dark:text-zinc-300';
+    percent >= 90 ? 'text-destructive' : percent >= 75 ? 'text-amber-500' : 'text-primary dark:text-zinc-300';
 
   return (
     <Tooltip>
@@ -237,21 +220,12 @@ export function ContextUsageIndicator({
           )}
           aria-label={`${usageLabelWithSuffix} ${usageFullLabel}. ${usageTokensLabel}`}
         >
-          <ProgressCircle
-            value={percent}
-            className={cn('size-3.5', progressClassName)}
-          />
+          <ProgressCircle value={percent} className={cn('size-3.5', progressClassName)} />
         </button>
       </TooltipTrigger>
-      <TooltipContent
-        side="top"
-        sideOffset={6}
-        className="space-y-0.5 px-3 py-2 text-center"
-      >
+      <TooltipContent side="top" sideOffset={6} className="space-y-0.5 px-3 py-2 text-center">
         <div className="text-primary-foreground/70">{usageLabelWithSuffix}</div>
-        <div className="font-medium text-primary-foreground/80">
-          {usageFullLabel}
-        </div>
+        <div className="font-medium text-primary-foreground/80">{usageFullLabel}</div>
         <div className="text-sm font-semibold">{usageTokensLabel}</div>
       </TooltipContent>
     </Tooltip>


### PR DESCRIPTION
## Summary

This defers the thread context usage indicator until the hosted ChatKit API configuration is complete. While a parent integration is still resolving the client secret, the chat shell can render without immediately calling assistant or thread context usage APIs with an empty credential.

## Root Cause

`ContextUsageIndicator` only checked whether the SDK client existed before loading assistant context size and thread usage. During parent-driven client secret initialization, the app can create the stream client before a non-empty client secret is available, so the indicator could issue context usage requests too early.

## Fix

The indicator now derives a `hasApiConfiguration` guard from both `apiUrl` and `apiKey`, resets usage state while configuration is incomplete, and waits until the client secret is available before loading context size or usage. Added coverage for the initializing shell and for the indicator waiting until API configuration is ready.

## Validation

- `pnpm --filter @xpert-ai/chatkit-ui exec prettier --check src/components/thread/context-usage-indicator.tsx src/App.test.tsx src/components/thread/context-usage-indicator.test.tsx ../../.changeset/defer-context-usage-loading.md`
- `pnpm --filter @xpert-ai/chatkit-ui test -- src/App.test.tsx src/components/thread/context-usage-indicator.test.tsx`
- `git diff --check`