### PR TITLE
Add message navigation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "privatePackages": {
-    "version": true,
+    "version": false,
     "tag": false
   }
 }

--- a/.changeset/small-drinks-sniff.md
+++ b/.changeset/small-drinks-sniff.md
@@ -1,0 +1,6 @@
+---
+'@xpert-ai/chatkit-ui': patch
+'@xpert-ai/chatkit-types': patch
+---
+
+message navigation

--- a/packages/chatkit-ui/src/components/chat.message-navigation.test.tsx
+++ b/packages/chatkit-ui/src/components/chat.message-navigation.test.tsx
@@ -1,0 +1,295 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatKitOptions } from '@xpert-ai/chatkit-types';
+import type { MessageNavigationItem } from '../lib/message-navigation';
+
+const mocks = vi.hoisted(() => ({
+  refreshThreads: vi.fn().mockResolvedValue(undefined),
+  stream: {
+    client: {
+      contexts: {
+        fetch: vi.fn(),
+        deleteFile: vi.fn(),
+      },
+      assistants: {
+        get: vi.fn(() => new Promise(() => undefined)),
+        getRuntimeCapabilities: vi.fn(() => new Promise(() => undefined)),
+      },
+      conversations: {
+        search: vi.fn().mockResolvedValue({ items: [] }),
+        update: vi.fn(),
+      },
+    },
+    apiUrl: 'https://api.example.com',
+    assistantId: 'assistant-1',
+    apiKey: 'secret',
+    organizationId: undefined,
+    threadId: 'thread-1' as string | null,
+    contextUsageByAgentKey: {},
+    values: {
+      messages: [] as Array<{
+        id?: string;
+        type: string;
+        content: unknown;
+        createdAt?: string;
+        updatedAt?: string;
+      }>,
+    },
+    messages: [] as Array<{
+      id?: string;
+      type: string;
+      content: unknown;
+      createdAt?: string;
+      updatedAt?: string;
+    }>,
+    historyMessagePagination: {
+      conversationId: null as string | null,
+      loadedCount: 0,
+      total: 0,
+      hasMore: false,
+      isLoadingMore: false,
+    },
+    todos: null,
+    runtimeActivities: {
+      sandboxServices: {
+        providerId: 'sandbox-services',
+        services: [],
+        isRefreshing: false,
+        refreshedAt: null,
+        error: null as unknown,
+      },
+    },
+    pendingFollowUps: [],
+    pendingRequestUserInput: null,
+    pendingHITLRequest: null,
+    isLoading: false,
+    isReady: true,
+    error: null as unknown,
+    loadThread: vi.fn(),
+    loadConversationMessages: vi.fn(),
+    loadMoreConversationMessages: vi.fn(),
+    submit: vi.fn(),
+    stop: vi.fn(),
+    reset: vi.fn(),
+    removePendingFollowUp: vi.fn(),
+    canSendPendingFollowUpNow: vi.fn().mockReturnValue(false),
+    sendPendingFollowUpNow: vi.fn(),
+    promotePendingFollowUpToSteer: vi.fn(),
+    submitRequestUserInput: vi.fn(),
+    submitHITLDecision: vi.fn(),
+    stopRuntimeActivityItem: vi.fn(),
+    setThreadId: vi.fn(),
+  },
+}));
+
+vi.mock('../providers/Stream', () => ({
+  useStreamContext: () => mocks.stream,
+}));
+
+vi.mock('../hooks/useStream', () => ({
+  useStreamManager: () => ({
+    stream: mocks.stream,
+    streamRef: { current: mocks.stream },
+    setStream: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useThreads', () => ({
+  useThreads: () => ({
+    threads: [],
+    deleteThread: vi.fn(),
+    refreshThreads: mocks.refreshThreads,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('../i18n/useChatkitTranslation', () => ({
+  useChatkitTranslation: () => ({
+    t: (key: string, options?: { count?: number; defaultValue?: string }) => {
+      const labels: Record<string, string> = {
+        'chat.title': 'Chat',
+        'chat.statusOnline': 'Online',
+        'chat.youLabel': 'You',
+        'chat.poweredBy': 'Powered by Xpert AI',
+        'chat.placeholder': 'Type a message...',
+        'message.reasoning': 'Reasoning',
+        'message.navigation.label': 'Message navigation',
+        'message.navigation.system': 'System',
+        'message.navigation.tool': 'Tool',
+        'message.navigation.event': 'Event',
+        'message.navigation.message': 'Message',
+        'message.navigation.image': 'Image',
+        'message.navigation.memory': 'Memory',
+        'message.navigation.widget': 'Widget',
+        'message.navigation.mcpApp': 'MCP App',
+        'message.navigation.attachment': 'Attachment',
+        'message.navigation.reference': 'Reference',
+        'message.navigation.capability': 'Capability',
+        'message.navigation.moreTags': `+${options?.count ?? 0}`,
+      };
+      return labels[key] ?? options?.defaultValue ?? key;
+    },
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+vi.mock('../providers/Theme', () => ({
+  useTheme: () => ({
+    theme: { radius: 'soft' },
+    isDarkMode: false,
+  }),
+}));
+
+vi.mock('../hooks/useParentMessenger', () => ({
+  useParentMessenger: () => undefined,
+}));
+
+vi.mock('./thread/MessageNavigator', () => ({
+  MessageNavigator: ({
+    items,
+    label,
+  }: {
+    items: MessageNavigationItem[];
+    label: string;
+  }) => (
+    <nav aria-label={label} data-count={items.length} data-testid="message-nav">
+      {items.map((item) => (
+        <button key={item.id} type="button">
+          {item.preview}
+        </button>
+      ))}
+    </nav>
+  ),
+}));
+
+vi.mock('./composer/ComposerMenu', () => ({
+  ComposerMenu: () => <div data-testid="composer-menu" />,
+}));
+
+vi.mock('./composer/SendButton', () => ({
+  SendButton: ({ disabled }: { disabled?: boolean }) => (
+    <button type="submit" disabled={disabled}>
+      send
+    </button>
+  ),
+}));
+
+vi.mock('./history/HistorySidebar', () => ({
+  HistorySidebar: () => null,
+}));
+
+vi.mock('./composer/pending-follow-ups', () => ({
+  PendingFollowUps: () => null,
+}));
+
+vi.mock('./composer/pending-todos', () => ({
+  PendingTodos: () => null,
+}));
+
+vi.mock('./composer/pending-runtime-services', () => ({
+  PendingRuntimeServices: () => null,
+}));
+
+vi.mock('./composer/request-user-input-panel', () => ({
+  RequestUserInputPanel: () => null,
+}));
+
+vi.mock('./composer/hitl-approval-panel', () => ({
+  HITLApprovalPanel: () => null,
+}));
+
+vi.mock('./thread/messages/ai', () => ({
+  AssistantMessage: () => null,
+  AssistantStreamingIndicator: () => null,
+}));
+
+vi.mock('./thread/MessageActions', () => ({
+  MessageActions: () => null,
+}));
+
+vi.mock('./ui/chatkit-avatar', () => ({
+  ChatkitAvatar: () => null,
+  extractAssistantAvatar: () => null,
+}));
+
+vi.mock('./thread/context-usage-indicator', () => ({
+  ContextUsageIndicator: () => null,
+}));
+
+import { Chat } from './chat';
+
+const baseOptions: ChatKitOptions = {
+  api: {
+    apiUrl: 'https://api.example.com',
+    xpertId: 'assistant-1',
+    getClientSecret: async () => 'secret',
+  },
+};
+
+function setMessages(count = 3) {
+  mocks.stream.messages = Array.from({ length: count }, (_, index) => [
+    {
+      id: `human-${index + 1}`,
+      type: 'human',
+      content: `User message ${index + 1}`,
+    },
+    {
+      id: `assistant-${index + 1}`,
+      type: 'ai',
+      content: `AI message ${index + 1}`,
+    },
+  ]).flat();
+  mocks.stream.values = { messages: mocks.stream.messages };
+}
+
+describe('Chat message navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMessages(3);
+  });
+
+  it('shows message navigation by default once enough messages are loaded', () => {
+    render(<Chat options={baseOptions} />);
+
+    expect(screen.getByTestId('message-nav')).toHaveAttribute(
+      'data-count',
+      '3',
+    );
+    expect(
+      screen.getByRole('button', { name: 'AI message 1' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('navigation', { name: 'Message navigation' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides message navigation when disabled through ChatKit options', () => {
+    render(
+      <Chat
+        options={{
+          ...baseOptions,
+          messageNavigation: { enabled: false },
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId('message-nav')).not.toBeInTheDocument();
+  });
+
+  it('updates navigation items when older history messages are added', () => {
+    const { rerender } = render(<Chat options={baseOptions} />);
+    expect(screen.getByTestId('message-nav')).toHaveAttribute(
+      'data-count',
+      '3',
+    );
+
+    setMessages(4);
+    rerender(<Chat options={baseOptions} />);
+
+    expect(screen.getByTestId('message-nav')).toHaveAttribute(
+      'data-count',
+      '4',
+    );
+  });
+});

--- a/packages/chatkit-ui/src/components/chat.tsx
+++ b/packages/chatkit-ui/src/components/chat.tsx
@@ -67,6 +67,7 @@ import {
   AssistantMessage,
   AssistantStreamingIndicator,
 } from './thread/messages/ai';
+import { MessageNavigator } from './thread/MessageNavigator';
 import { MessageActions } from './thread/MessageActions';
 import { StartScreen } from './thread/StartScreen';
 import {
@@ -93,9 +94,7 @@ import {
   type ComposerValuePayload,
 } from '../lib/references';
 import { getMissingApiConfigurationKind } from '../lib/api-config';
-import {
-  sortVisiblePendingFollowUps,
-} from '../lib/follow-ups';
+import { sortVisiblePendingFollowUps } from '../lib/follow-ups';
 import { useTheme } from '../providers/Theme';
 import { useParentMessenger } from '../hooks/useParentMessenger';
 import { PetBridge } from './pet/PetBridge';
@@ -163,6 +162,14 @@ import {
   type RuntimeCapabilitiesWithCommands,
   type RuntimeCapabilityPaletteState,
 } from '../lib/slash-commands';
+import {
+  buildMessageNavigationItems,
+  getMessageNavigationItemId,
+  MESSAGE_NAVIGATION_MIN_ITEMS,
+  type MessageNavigationItem,
+  type MessageNavigationLabels,
+  type MessageNavigationSourceMessage,
+} from '../lib/message-navigation';
 
 export type ChatProps = {
   className?: string;
@@ -489,12 +496,14 @@ export function Chat({
   clientSecret = '',
   isClientSecretInitializing = false,
 }: ChatProps) {
-  const { t } = useChatkitTranslation();
+  const { t, i18n } = useChatkitTranslation();
   const composer = options?.composer;
   const startScreen = options?.startScreen;
   const history = options?.history;
   const disclaimer = options?.disclaimer;
   const apiUrl = options?.api?.apiUrl || defaultApiUrl;
+  const messageNavigationEnabled =
+    options?.messageNavigation?.enabled !== false;
   const { setStream } = useStreamManager();
   const stream = useStreamContext();
   const { theme } = useTheme();
@@ -643,6 +652,9 @@ export function Chat({
     isLoading: isThreadsLoading,
   } = useThreads();
   const viewportRef = React.useRef<HTMLDivElement>(null);
+  const messageNavigationAnchorsRef = React.useRef(
+    new Map<string, HTMLDivElement>(),
+  );
   const attachmentsRef = React.useRef<ChatAttachmentsHandle>(null);
   const composerInputRef = React.useRef<HTMLDivElement>(null);
   const slashPaletteRef = React.useRef<HTMLDivElement>(null);
@@ -663,6 +675,7 @@ export function Chat({
 
   const resolvedTitle = title ?? t('chat.title');
   const resolvedPlaceholder = placeholder ?? t('chat.placeholder');
+  const assistantTitle = assistantName || resolvedTitle;
   const petRequired = options?.displayMode === 'pet';
   const basePetSettings = React.useMemo(
     () => derivePetLocalSettings(options?.pet),
@@ -727,6 +740,47 @@ export function Chat({
     () => stream.messages ?? [],
     [stream.messages],
   );
+  const messageNavigationLabels = React.useMemo<MessageNavigationLabels>(
+    () => ({
+      user: t('chat.youLabel'),
+      assistant: assistantTitle,
+      system: t('message.navigation.system'),
+      tool: t('message.navigation.tool'),
+      event: t('message.navigation.event'),
+      message: t('message.navigation.message'),
+      image: t('message.navigation.image'),
+      memory: t('message.navigation.memory'),
+      widget: t('message.navigation.widget'),
+      mcpApp: t('message.navigation.mcpApp'),
+      attachment: t('message.navigation.attachment'),
+      reference: t('message.navigation.reference'),
+      capability: t('message.navigation.capability'),
+      reasoning: t('message.reasoning'),
+    }),
+    [assistantTitle, t],
+  );
+  const messageNavigationItems = React.useMemo(
+    () =>
+      messageNavigationEnabled
+        ? buildMessageNavigationItems(
+            messages as MessageNavigationSourceMessage[],
+            {
+              labels: messageNavigationLabels,
+              language: i18n.language,
+              assistantTitle,
+            },
+          )
+        : [],
+    [
+      assistantTitle,
+      i18n.language,
+      messageNavigationEnabled,
+      messageNavigationLabels,
+      messages,
+    ],
+  );
+  const showMessageNavigation =
+    messageNavigationItems.length >= MESSAGE_NAVIGATION_MIN_ITEMS;
   const historyMessagePagination = stream.historyMessagePagination;
   const isLoadingMoreMessages = Boolean(
     historyMessagePagination?.isLoadingMore,
@@ -761,17 +815,14 @@ export function Chat({
     () => getRuntimeCapabilityOptions(runtimeCapabilities),
     [runtimeCapabilities],
   );
-  const goalAdapter = React.useMemo<ChatKitGoalAdapter | null>(
-    () => {
-      if (isGoalAdapter(options?.goal)) {
-        return options.goal;
-      }
-      return supportsXpertThreadGoalAdapter(stream.client)
-        ? createXpertThreadGoalAdapter(stream.client)
-        : null;
-    },
-    [options?.goal, stream.client],
-  );
+  const goalAdapter = React.useMemo<ChatKitGoalAdapter | null>(() => {
+    if (isGoalAdapter(options?.goal)) {
+      return options.goal;
+    }
+    return supportsXpertThreadGoalAdapter(stream.client)
+      ? createXpertThreadGoalAdapter(stream.client)
+      : null;
+  }, [options?.goal, stream.client]);
   const displayedGoalElapsedSeconds = threadGoal
     ? (threadGoal.elapsedSeconds ?? 0) +
       (goalElapsedStartedAt
@@ -1099,6 +1150,28 @@ export function Chat({
     },
     [cancelPendingAutoScroll, enableAutoFollow],
   );
+
+  const setMessageNavigationAnchor = React.useCallback(
+    (id: string, node: HTMLDivElement | null) => {
+      if (node) {
+        messageNavigationAnchorsRef.current.set(id, node);
+        return;
+      }
+      messageNavigationAnchorsRef.current.delete(id);
+    },
+    [],
+  );
+
+  const getMessageNavigationAnchor = React.useCallback(
+    (item: MessageNavigationItem) =>
+      messageNavigationAnchorsRef.current.get(item.id) ?? null,
+    [],
+  );
+
+  const handleMessageNavigationNavigate = React.useCallback(() => {
+    disableAutoFollow();
+    clearQuoteSelection();
+  }, [clearQuoteSelection, disableAutoFollow]);
 
   React.useEffect(() => {
     const viewport = viewportRef.current;
@@ -1973,12 +2046,9 @@ export function Chat({
     ],
   );
 
-  const handleGoalPanelOpenChange = React.useCallback(
-    (open: boolean) => {
-      setIsGoalPanelOpen(open);
-    },
-    [],
-  );
+  const handleGoalPanelOpenChange = React.useCallback((open: boolean) => {
+    setIsGoalPanelOpen(open);
+  }, []);
 
   const addRunRuntimeCapabilities = React.useCallback(
     (selection: RuntimeCapabilitiesSelection) => {
@@ -2588,7 +2658,9 @@ export function Chat({
         const nextViewport = viewportRef.current;
         if (nextViewport) {
           const nextScrollTop =
-            nextViewport.scrollHeight - previousScrollHeight + previousScrollTop;
+            nextViewport.scrollHeight -
+            previousScrollHeight +
+            previousScrollTop;
           nextViewport.scrollTop = Math.max(0, nextScrollTop);
           previousScrollTopRef.current = nextViewport.scrollTop;
         }
@@ -2764,7 +2836,6 @@ export function Chat({
     fallbackTitle: t('history.threadFallback'),
   });
 
-  const assistantTitle = assistantName || resolvedTitle;
   const layoutMaxWidth = options?.layout?.maxWidth;
   const chatColumnStyle = React.useMemo<React.CSSProperties | undefined>(() => {
     if (
@@ -2904,6 +2975,19 @@ export function Chat({
         </div>
       </div>
 
+      {showMessageNavigation && (
+        <MessageNavigator
+          items={messageNavigationItems}
+          viewportRef={viewportRef}
+          getAnchor={getMessageNavigationAnchor}
+          onNavigate={handleMessageNavigationNavigate}
+          label={t('message.navigation.label')}
+          tagsOverflowLabel={(count) =>
+            t('message.navigation.moreTags', { count })
+          }
+        />
+      )}
+
       <div
         data-slot="chatkit-chat-content"
         className="mx-auto w-full flex-1 p-4"
@@ -3014,6 +3098,10 @@ export function Chat({
                 message.type === 'human' || isAssistantMessage;
               const quoteSource =
                 message.type === 'human' ? t('chat.youLabel') : assistantTitle;
+              const messageNavigationId = getMessageNavigationItemId(
+                message as MessageNavigationSourceMessage,
+                index,
+              );
 
               if (
                 !isAssistantMessage &&
@@ -3028,6 +3116,10 @@ export function Chat({
               return (
                 <div
                   key={message.id ?? `${message.type}-${index}`}
+                  ref={(node) =>
+                    setMessageNavigationAnchor(messageNavigationId, node)
+                  }
+                  data-message-navigation-id={messageNavigationId}
                   className={cn(
                     'group flex gap-3',
                     message.type === 'human'
@@ -3392,7 +3484,8 @@ export function Chat({
                       disabled={isGoalLoading}
                       onClick={() =>
                         void handleGoalCommand({
-                          args: threadGoal.status === 'paused' ? 'resume' : 'pause',
+                          args:
+                            threadGoal.status === 'paused' ? 'resume' : 'pause',
                           commandSource: {
                             type: 'slash_command',
                             name: 'goal',

--- a/packages/chatkit-ui/src/components/thread/MessageNavigator.test.tsx
+++ b/packages/chatkit-ui/src/components/thread/MessageNavigator.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MessageNavigator } from './MessageNavigator';
+import type { MessageNavigationItem } from '../../lib/message-navigation';
+
+const items: MessageNavigationItem[] = [
+  {
+    id: 'message-1',
+    messageId: 'message-1',
+    index: 0,
+    role: 'user',
+    title: 'You',
+    preview: 'First message',
+    tags: [],
+  },
+  {
+    id: 'message-2',
+    messageId: 'message-2',
+    index: 1,
+    role: 'assistant',
+    title: 'Assistant',
+    preview: 'Loaded a tool',
+    tags: ['README.md', 'types.ts', 'search', 'extra'],
+  },
+];
+
+const waveItems: MessageNavigationItem[] = Array.from(
+  { length: 5 },
+  (_, index) => ({
+    id: `wave-${index + 1}`,
+    messageId: `wave-${index + 1}`,
+    index,
+    role: index % 2 === 0 ? 'user' : 'assistant',
+    title: `Message ${index + 1}`,
+    preview: `Preview ${index + 1}`,
+    tags: [],
+  }),
+);
+
+function setReadonlyNumberProperty(
+  element: HTMLElement,
+  property: 'clientHeight' | 'scrollHeight' | 'offsetTop',
+  value: number,
+) {
+  Object.defineProperty(element, property, {
+    configurable: true,
+    value,
+  });
+}
+
+function setupNavigator(navigationItems = items) {
+  const viewport = document.createElement('div');
+  const scrollTo = vi.fn();
+
+  setReadonlyNumberProperty(viewport, 'clientHeight', 400);
+  setReadonlyNumberProperty(viewport, 'scrollHeight', 1000);
+  setReadonlyNumberProperty(viewport, 'offsetTop', 0);
+  viewport.scrollTo = scrollTo;
+
+  const anchors = new Map(
+    navigationItems.map((item, index) => {
+      const anchor = document.createElement('div');
+      setReadonlyNumberProperty(anchor, 'offsetTop', index * 240);
+      return [item.id, anchor] as const;
+    }),
+  );
+
+  render(
+    <MessageNavigator
+      items={navigationItems}
+      viewportRef={{ current: viewport }}
+      getAnchor={(item) => anchors.get(item.id) ?? null}
+      label="Message navigation"
+      tagsOverflowLabel={(count) => `+${count}`}
+    />,
+  );
+
+  return { viewport, scrollTo };
+}
+
+function getMarkerLine(button: HTMLElement) {
+  const line = button.querySelector('span');
+  expect(line).not.toBeNull();
+  return line as HTMLElement;
+}
+
+describe('MessageNavigator', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders markers in item order without inline top positioning', () => {
+    setupNavigator();
+
+    const buttons = screen.getAllByRole('button');
+
+    expect(buttons.map((button) => button.getAttribute('aria-label'))).toEqual([
+      'You: First message',
+      'Assistant: Loaded a tool',
+    ]);
+    for (const button of buttons) {
+      expect(button).not.toHaveAttribute('style');
+    }
+    expect(getMarkerLine(buttons[1])).toHaveClass('w-2');
+  });
+
+  it('tightens marker spacing and creates a width wave around hover', () => {
+    setupNavigator(waveItems);
+
+    const buttons = screen.getAllByRole('button');
+    fireEvent.mouseEnter(
+      screen.getByRole('button', { name: /Message 3: Preview 3/ }),
+    );
+
+    expect(buttons[0].parentElement).toHaveClass('h-3.5');
+    expect(getMarkerLine(buttons[0])).toHaveClass('w-3.5');
+    expect(getMarkerLine(buttons[1])).toHaveClass('w-5');
+    expect(getMarkerLine(buttons[2])).toHaveClass('w-7');
+    expect(getMarkerLine(buttons[3])).toHaveClass('w-5');
+    expect(getMarkerLine(buttons[4])).toHaveClass('w-3.5');
+  });
+
+  it('shows a hover preview with tags and overflow count', () => {
+    setupNavigator();
+
+    fireEvent.mouseEnter(
+      screen.getByRole('button', { name: /Assistant: Loaded a tool/ }),
+    );
+
+    expect(screen.getByText('Loaded a tool')).toBeInTheDocument();
+    expect(screen.getByText('README.md')).toBeInTheDocument();
+    expect(screen.getByText('types.ts')).toBeInTheDocument();
+    expect(screen.getByText('search')).toBeInTheDocument();
+    expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+
+  it('scrolls the viewport to the selected message anchor', () => {
+    const { scrollTo } = setupNavigator();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Assistant: Loaded a tool/ }),
+    );
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 228,
+      behavior: 'smooth',
+    });
+  });
+
+  it('updates the active marker as the viewport scrolls', async () => {
+    const { viewport } = setupNavigator();
+
+    viewport.scrollTop = 260;
+    fireEvent.scroll(viewport);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /Assistant: Loaded a tool/ }),
+      ).toHaveAttribute('aria-current', 'location'),
+    );
+  });
+});

--- a/packages/chatkit-ui/src/components/thread/MessageNavigator.tsx
+++ b/packages/chatkit-ui/src/components/thread/MessageNavigator.tsx
@@ -1,0 +1,231 @@
+import * as React from 'react';
+
+import type { MessageNavigationItem } from '../../lib/message-navigation';
+import { cn } from '../../lib/utils';
+
+export type MessageNavigatorProps = {
+  items: MessageNavigationItem[];
+  viewportRef: React.RefObject<HTMLElement | null>;
+  getAnchor: (item: MessageNavigationItem) => HTMLElement | null;
+  onNavigate?: () => void;
+  className?: string;
+  label: string;
+  tagsOverflowLabel: (count: number) => string;
+};
+
+const ACTIVE_OFFSET_PX = 12;
+
+function getMarkerWidthClass(
+  index: number,
+  active: boolean,
+  interactionIndex: number,
+) {
+  if (interactionIndex >= 0) {
+    const distance = Math.abs(index - interactionIndex);
+    if (distance === 0) return 'w-7';
+    if (distance === 1) return 'w-5';
+    if (distance === 2) return 'w-3.5';
+    return 'w-2';
+  }
+
+  return active ? 'w-5' : 'w-2';
+}
+
+function getAnchorTop(viewport: HTMLElement, anchor: HTMLElement) {
+  return anchor.offsetTop - viewport.offsetTop;
+}
+
+function resolveActiveItemId(
+  items: MessageNavigationItem[],
+  viewport: HTMLElement | null,
+  getAnchor: (item: MessageNavigationItem) => HTMLElement | null,
+) {
+  if (!viewport || items.length === 0) return null;
+
+  const targetTop = viewport.scrollTop + ACTIVE_OFFSET_PX;
+  let activeId = items[0]?.id ?? null;
+
+  for (const item of items) {
+    const anchor = getAnchor(item);
+    if (!anchor) continue;
+    if (getAnchorTop(viewport, anchor) <= targetTop) {
+      activeId = item.id;
+      continue;
+    }
+    break;
+  }
+
+  return activeId;
+}
+
+function scrollToAnchor(viewport: HTMLElement, anchor: HTMLElement) {
+  const top = Math.max(0, getAnchorTop(viewport, anchor) - ACTIVE_OFFSET_PX);
+  if (typeof viewport.scrollTo === 'function') {
+    viewport.scrollTo({ top, behavior: 'smooth' });
+    return;
+  }
+  viewport.scrollTop = top;
+}
+
+export function MessageNavigator({
+  items,
+  viewportRef,
+  getAnchor,
+  onNavigate,
+  className,
+  label,
+  tagsOverflowLabel,
+}: MessageNavigatorProps) {
+  const [hoveredId, setHoveredId] = React.useState<string | null>(null);
+  const [focusedId, setFocusedId] = React.useState<string | null>(null);
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+
+  const updateActiveItem = React.useCallback(() => {
+    const viewport = viewportRef.current;
+    setActiveId(resolveActiveItemId(items, viewport, getAnchor));
+  }, [getAnchor, items, viewportRef]);
+
+  React.useLayoutEffect(() => {
+    updateActiveItem();
+  }, [updateActiveItem]);
+
+  React.useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    let frame: number | null = null;
+    const scheduleUpdate = () => {
+      if (frame !== null) return;
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        updateActiveItem();
+      });
+    };
+
+    viewport.addEventListener('scroll', scheduleUpdate, { passive: true });
+    window.addEventListener('resize', scheduleUpdate, { passive: true });
+
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(scheduleUpdate)
+        : null;
+    resizeObserver?.observe(viewport);
+
+    return () => {
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+      viewport.removeEventListener('scroll', scheduleUpdate);
+      window.removeEventListener('resize', scheduleUpdate);
+      resizeObserver?.disconnect();
+    };
+  }, [updateActiveItem, viewportRef]);
+
+  const handleNavigate = React.useCallback(
+    (item: MessageNavigationItem) => {
+      const viewport = viewportRef.current;
+      const anchor = getAnchor(item);
+      if (!viewport || !anchor) return;
+      onNavigate?.();
+      scrollToAnchor(viewport, anchor);
+      setActiveId(item.id);
+    },
+    [getAnchor, onNavigate, viewportRef],
+  );
+
+  if (items.length === 0) return null;
+
+  const interactionId = focusedId ?? hoveredId;
+  const interactionIndex = interactionId
+    ? items.findIndex((item) => item.id === interactionId)
+    : -1;
+
+  return (
+    <nav
+      aria-label={label}
+      className={cn(
+        'pointer-events-none sticky top-16 z-20 hidden h-0 w-0 shrink-0 self-start md:block',
+        className,
+      )}
+      data-slot="chatkit-message-navigator"
+    >
+      <div className="group/nav relative h-[calc(100vh-9rem)] w-12">
+        <div className="absolute left-2 top-1/2 flex max-h-full w-10 -translate-y-1/2 flex-col gap-0.5 py-1">
+          {items.map((item, index) => {
+            const isActive = item.id === activeId;
+            const isPreviewed = item.id === hoveredId || item.id === focusedId;
+
+            return (
+              <div key={item.id} className="relative h-3.5 w-10 shrink-0">
+                <button
+                  type="button"
+                  aria-label={`${item.title}: ${item.preview}`}
+                  aria-current={isActive ? 'location' : undefined}
+                  className={cn(
+                    'pointer-events-auto flex h-3.5 w-10 items-center justify-start rounded-sm outline-none',
+                    'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                  )}
+                  onClick={() => handleNavigate(item)}
+                  onMouseEnter={() => setHoveredId(item.id)}
+                  onMouseLeave={() =>
+                    setHoveredId((id) => (id === item.id ? null : id))
+                  }
+                  onFocus={() => setFocusedId(item.id)}
+                  onBlur={() =>
+                    setFocusedId((id) => (id === item.id ? null : id))
+                  }
+                >
+                  <span
+                    className={cn(
+                      'block h-0.5 rounded-full bg-muted-foreground/25 transition-all duration-150',
+                      getMarkerWidthClass(index, isActive, interactionIndex),
+                      isActive && 'bg-foreground',
+                      isPreviewed && 'bg-foreground',
+                      interactionIndex >= 0 &&
+                        !isActive &&
+                        !isPreviewed &&
+                        'bg-muted-foreground/35',
+                    )}
+                  />
+                </button>
+
+                {isPreviewed && (
+                  <div
+                    className={cn(
+                      'pointer-events-none absolute left-9 top-1/2 z-30 w-80 max-w-[min(20rem,calc(100vw-6rem))] -translate-y-1/2',
+                      'rounded-lg border border-border bg-background/95 p-3 text-left shadow-xl backdrop-blur',
+                    )}
+                  >
+                    <div className="mb-1 truncate text-sm font-medium text-foreground">
+                      {item.title}
+                    </div>
+                    <div className="line-clamp-2 text-sm leading-5 text-muted-foreground">
+                      {item.preview}
+                    </div>
+                    {item.tags.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-1.5">
+                        {item.tags.slice(0, 3).map((tag) => (
+                          <span
+                            key={tag}
+                            className="max-w-[8rem] truncate rounded-md bg-muted px-1.5 py-0.5 text-[11px] leading-4 text-muted-foreground"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                        {item.tags.length > 3 && (
+                          <span className="rounded-md bg-muted px-1.5 py-0.5 text-[11px] leading-4 text-muted-foreground">
+                            {tagsOverflowLabel(item.tags.length - 3)}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/packages/chatkit-ui/src/components/thread/context-usage-indicator.test.tsx
+++ b/packages/chatkit-ui/src/components/thread/context-usage-indicator.test.tsx
@@ -67,7 +67,7 @@ describe('ContextUsageIndicator', () => {
   it('does not load assistant context size before the client secret is ready', () => {
     const stream = createStream({ apiKey: '' });
     mockUseStreamContext.mockReturnValue(
-      stream as ReturnType<typeof useStreamContext>,
+      stream as unknown as ReturnType<typeof useStreamContext>,
     );
 
     render(<ContextUsageIndicator />);
@@ -79,7 +79,7 @@ describe('ContextUsageIndicator', () => {
   it('loads assistant context size once API configuration is available', async () => {
     const stream = createStream();
     mockUseStreamContext.mockReturnValue(
-      stream as ReturnType<typeof useStreamContext>,
+      stream as unknown as ReturnType<typeof useStreamContext>,
     );
 
     render(<ContextUsageIndicator />);

--- a/packages/chatkit-ui/src/i18n/locales/en-US.json
+++ b/packages/chatkit-ui/src/i18n/locales/en-US.json
@@ -263,6 +263,21 @@
     "loading": "Loading",
     "thinking": "Thinking",
     "answering": "Answering",
+    "navigation": {
+      "label": "Message navigation",
+      "system": "System",
+      "tool": "Tool",
+      "event": "Event",
+      "message": "Message",
+      "image": "Image",
+      "memory": "Memory",
+      "widget": "Widget",
+      "mcpApp": "MCP App",
+      "attachment": "Attachment",
+      "reference": "Reference",
+      "capability": "Capability",
+      "moreTags": "+{{count}}"
+    },
     "mcpApp": {
       "loading": "Loading MCP App"
     },

--- a/packages/chatkit-ui/src/i18n/locales/zh-CN.json
+++ b/packages/chatkit-ui/src/i18n/locales/zh-CN.json
@@ -263,6 +263,21 @@
     "loading": "正在加载",
     "thinking": "正在思考",
     "answering": "正在生成",
+    "navigation": {
+      "label": "消息导航",
+      "system": "系统",
+      "tool": "工具",
+      "event": "事件",
+      "message": "消息",
+      "image": "图片",
+      "memory": "记忆",
+      "widget": "组件",
+      "mcpApp": "MCP App",
+      "attachment": "附件",
+      "reference": "引用",
+      "capability": "能力",
+      "moreTags": "+{{count}}"
+    },
     "mcpApp": {
       "loading": "正在加载 MCP App"
     },

--- a/packages/chatkit-ui/src/lib/message-navigation.test.ts
+++ b/packages/chatkit-ui/src/lib/message-navigation.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildMessageNavigationItem,
+  buildMessageNavigationItems,
+  type MessageNavigationLabels,
+} from './message-navigation';
+
+const labels: MessageNavigationLabels = {
+  user: 'You',
+  assistant: 'Assistant',
+  system: 'System',
+  tool: 'Tool',
+  event: 'Event',
+  message: 'Message',
+  image: 'Image',
+  memory: 'Memory',
+  widget: 'Widget',
+  mcpApp: 'MCP App',
+  attachment: 'Attachment',
+  reference: 'Reference',
+  capability: 'Capability',
+  reasoning: 'Reasoning',
+};
+
+describe('message navigation extraction', () => {
+  it('builds one navigation item for each user and assistant message pair', () => {
+    const items = buildMessageNavigationItems(
+      [
+        {
+          id: 'human-1',
+          type: 'human',
+          content: 'Can you inspect the options file?',
+          fileAssets: [{ originalName: 'options.ts' }],
+        },
+        {
+          id: 'assistant-1',
+          type: 'ai',
+          content: [
+            {
+              type: 'text',
+              text: 'I checked options.ts and found the messageNavigation option.',
+            },
+            {
+              id: 'tool-1',
+              type: 'component',
+              data: {
+                category: 'Tool',
+                type: 'file',
+                title: 'read_file',
+                message: 'Read options.ts',
+                status: 'success',
+              },
+            },
+          ],
+        },
+      ],
+      { labels },
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      id: 'human-1',
+      messageId: 'human-1',
+      role: 'user',
+      title: 'Can you inspect the options file?',
+      preview: 'I checked options.ts and found the messageNavigation option.',
+    });
+    expect(items[0].tags).toEqual(
+      expect.arrayContaining(['Read options.ts', 'options.ts']),
+    );
+  });
+
+  it('extracts human text, files, references, and runtime capability tags', () => {
+    const item = buildMessageNavigationItem(
+      {
+        id: 'human-1',
+        type: 'human',
+        content: 'Please inspect these files.',
+        fileAssets: [{ originalName: 'README.md' }],
+        attachments: [{ name: 'diagram.png' }],
+        references: [
+          {
+            type: 'code',
+            path: 'src/app.ts',
+            startLine: 10,
+            endLine: 12,
+            text: 'const app = createApp()',
+          },
+        ],
+        runtimeCapabilityOptions: [{ label: 'Plan Mode' }],
+      },
+      0,
+      { labels },
+    );
+
+    expect(item).toMatchObject({
+      id: 'human-1',
+      messageId: 'human-1',
+      role: 'user',
+      title: 'You',
+      preview: 'Please inspect these files.',
+    });
+    expect(item?.tags).toEqual(
+      expect.arrayContaining([
+        'README.md',
+        'diagram.png',
+        'app.ts 10-12',
+        'Plan Mode',
+      ]),
+    );
+  });
+
+  it('extracts assistant text, reasoning, tools, widgets, and MCP app tags', () => {
+    const item = buildMessageNavigationItem(
+      {
+        id: 'assistant-1',
+        type: 'assistant',
+        content: [
+          { type: 'text', text: 'I found the relevant files.' },
+          {
+            id: 'tool-1',
+            type: 'component',
+            data: {
+              category: 'Tool',
+              type: 'file',
+              title: 'read_file',
+              message: 'Read README.md',
+              status: 'success',
+            },
+          },
+          {
+            id: 'widget-1',
+            type: 'component',
+            data: {
+              type: 'Widget',
+              mode: 'inline',
+              widgets: [{ name: 'Sales Dashboard' }],
+            },
+          },
+          {
+            id: 'mcp-1',
+            type: 'component',
+            data: {
+              type: 'McpApp',
+              appInstanceId: 'app-1',
+              resourceUri: 'ui://tool/result',
+              toolName: 'inspect_repo',
+              title: { en_US: 'Repo Inspector', zh_Hans: '仓库检查器' },
+              description: 'Interactive inspection result',
+            },
+          },
+        ],
+        reasoning: [{ type: 'reasoning', text: 'Need to inspect first.' }],
+      },
+      1,
+      { labels, assistantTitle: 'Code Assistant', language: 'en-US' },
+    );
+
+    expect(item).toMatchObject({
+      id: 'assistant-1',
+      role: 'assistant',
+      title: 'Code Assistant',
+      preview: expect.stringContaining('I found the relevant files.'),
+    });
+    expect(item?.tags).toEqual(
+      expect.arrayContaining([
+        'Read README.md',
+        'Sales Dashboard',
+        'Repo Inspector',
+        'Reasoning',
+      ]),
+    );
+  });
+
+  it('ignores empty messages and internal thread context usage artifacts', () => {
+    const items = buildMessageNavigationItems(
+      [
+        {
+          id: 'human-1',
+          type: 'human',
+          content: 'Only include this if an assistant answer follows.',
+        },
+        {
+          id: 'internal-1',
+          type: 'assistant',
+          content: [
+            {
+              type: 'thread_context_usage',
+              threadId: 'thread-1',
+              agentKey: 'agent',
+              usage: { totalTokens: 100 },
+            },
+          ],
+        },
+        {
+          id: 'empty-1',
+          type: 'assistant',
+          content: '',
+        },
+      ],
+      { labels },
+    );
+
+    expect(items).toEqual([]);
+  });
+
+  it('uses localized labels and localized MCP app titles', () => {
+    const zhLabels: MessageNavigationLabels = {
+      ...labels,
+      user: '你',
+      assistant: '助手',
+      system: '系统',
+    };
+    const item = buildMessageNavigationItem(
+      {
+        id: 'mcp-zh',
+        type: 'assistant',
+        content: [
+          {
+            id: 'mcp-zh-component',
+            type: 'component',
+            data: {
+              type: 'McpApp',
+              appInstanceId: 'app-zh',
+              resourceUri: 'ui://tool/result',
+              toolName: 'inspect_repo',
+              title: { en_US: 'Repo Inspector', zh_Hans: '仓库检查器' },
+            },
+          },
+        ],
+      },
+      0,
+      { labels: zhLabels, language: 'zh-Hans' },
+    );
+
+    expect(item?.title).toBe('助手');
+    expect(item?.tags).toContain('仓库检查器');
+  });
+});

--- a/packages/chatkit-ui/src/lib/message-navigation.ts
+++ b/packages/chatkit-ui/src/lib/message-navigation.ts
@@ -1,0 +1,472 @@
+import type {
+  ChatKitReference,
+  TMessageComponentMcpAppData,
+  TMessageComponentWidgetData,
+  TMessageContentComplex,
+  TMessageContentComponent,
+  TMessageContentMemory,
+  TMessageContentReasoning,
+  TMessageContentText,
+} from '@xpert-ai/chatkit-types';
+
+import { resolveLocalizedText } from '../i18n/localized-text';
+import { getReferenceLabel, normalizeReferences } from './references';
+import { isThreadContextUsageRenderArtifact } from './thread-context-usage';
+import {
+  getToolActivityLabel,
+  getToolStepData,
+} from '../components/thread/messages/tool-component-group';
+
+export const MESSAGE_NAVIGATION_MIN_ITEMS = 3;
+const MAX_PREVIEW_LENGTH = 180;
+const MAX_TAG_LENGTH = 40;
+
+export type MessageNavigationRole =
+  | 'user'
+  | 'assistant'
+  | 'system'
+  | 'tool'
+  | 'event'
+  | 'message';
+
+export type MessageNavigationItem = {
+  id: string;
+  messageId?: string;
+  index: number;
+  role: MessageNavigationRole;
+  title: string;
+  preview: string;
+  tags: string[];
+};
+
+export type MessageNavigationLabels = {
+  user: string;
+  assistant: string;
+  system: string;
+  tool: string;
+  event: string;
+  message: string;
+  image: string;
+  memory: string;
+  widget: string;
+  mcpApp: string;
+  attachment: string;
+  reference: string;
+  capability: string;
+  reasoning: string;
+};
+
+export type MessageNavigationSourceMessage = {
+  id?: unknown;
+  type?: unknown;
+  content?: unknown;
+  reasoning?: unknown;
+  attachments?: unknown;
+  fileAssets?: unknown;
+  references?: unknown;
+  submittedInput?: unknown;
+  runtimeCapabilityOptions?: unknown;
+};
+
+export type BuildMessageNavigationItemsOptions = {
+  labels: MessageNavigationLabels;
+  language?: string;
+  assistantTitle?: string | null;
+};
+
+type NavigationDraft = {
+  text: string[];
+  tags: string[];
+};
+
+type PendingUserNavigationItem = {
+  item: MessageNavigationItem;
+};
+
+type CollectContentOptions = {
+  includeComponentText?: boolean;
+};
+
+type RuntimeCapabilityOptionLike = {
+  label?: unknown;
+  type?: unknown;
+  id?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function normalizeWhitespace(value: string) {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string, maxLength: number) {
+  const normalized = normalizeWhitespace(value);
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}...`;
+}
+
+function pushText(draft: NavigationDraft, value: unknown) {
+  const text = readString(value);
+  if (text) draft.text.push(text);
+}
+
+function pushTag(draft: NavigationDraft, value: unknown) {
+  const tag = readString(value);
+  if (!tag) return;
+  const normalized = truncate(tag, MAX_TAG_LENGTH);
+  if (!draft.tags.includes(normalized)) {
+    draft.tags.push(normalized);
+  }
+}
+
+function mergeTags(...tagGroups: string[][]) {
+  const tags: string[] = [];
+  for (const group of tagGroups) {
+    for (const tag of group) {
+      if (!tags.includes(tag)) tags.push(tag);
+    }
+  }
+  return tags;
+}
+
+export function getMessageNavigationItemId(
+  message: MessageNavigationSourceMessage,
+  index: number,
+) {
+  const messageId = readString(message.id);
+  if (messageId) return messageId;
+  const type = readString(message.type) ?? 'message';
+  return `${type}-${index}`;
+}
+
+export function getMessageNavigationRole(type: unknown): MessageNavigationRole {
+  const normalized = readString(type)?.toLowerCase();
+  if (normalized === 'human' || normalized === 'user') return 'user';
+  if (normalized === 'ai' || normalized === 'assistant') return 'assistant';
+  if (normalized === 'system') return 'system';
+  if (normalized === 'tool') return 'tool';
+  if (normalized === 'event') return 'event';
+  return 'message';
+}
+
+function isTextContent(
+  content: TMessageContentComplex,
+): content is TMessageContentText {
+  return content.type === 'text';
+}
+
+function isReasoningContent(
+  content: TMessageContentComplex,
+): content is TMessageContentReasoning {
+  return content.type === 'reasoning';
+}
+
+function isComponentContent(
+  content: TMessageContentComplex,
+): content is TMessageContentComponent {
+  return content.type === 'component';
+}
+
+function isMemoryContent(
+  content: TMessageContentComplex,
+): content is TMessageContentMemory {
+  return content.type === 'memory';
+}
+
+function isWidgetComponent(
+  content: TMessageContentComponent,
+): content is TMessageContentComponent<TMessageComponentWidgetData> {
+  const data = content.data as Record<string, unknown> | undefined;
+  return data?.type === 'Widget' && Array.isArray(data.widgets);
+}
+
+function isMcpAppComponent(
+  content: TMessageContentComponent,
+): content is TMessageContentComponent<TMessageComponentMcpAppData> {
+  const data = content.data as Record<string, unknown> | undefined;
+  return data?.type === 'McpApp' && typeof data.appInstanceId === 'string';
+}
+
+function collectWidgetContent(
+  draft: NavigationDraft,
+  content: TMessageContentComponent<TMessageComponentWidgetData>,
+  labels: MessageNavigationLabels,
+) {
+  const names = content.data.widgets
+    .map((widget) => readString(widget.name))
+    .filter((name): name is string => Boolean(name));
+  if (names.length === 0) {
+    pushTag(draft, labels.widget);
+    return;
+  }
+  for (const name of names) {
+    pushTag(draft, name);
+  }
+}
+
+function collectMcpAppContent(
+  draft: NavigationDraft,
+  content: TMessageContentComponent<TMessageComponentMcpAppData>,
+  labels: MessageNavigationLabels,
+  language: string,
+) {
+  const title =
+    readString(resolveLocalizedText(content.data.title, language)) ??
+    readString(content.data.toolName) ??
+    labels.mcpApp;
+  pushTag(draft, title);
+  pushText(draft, resolveLocalizedText(content.data.description, language));
+}
+
+function collectComponentContent(
+  draft: NavigationDraft,
+  content: TMessageContentComponent,
+  labels: MessageNavigationLabels,
+  language: string,
+  options: CollectContentOptions,
+) {
+  if (isWidgetComponent(content)) {
+    collectWidgetContent(draft, content, labels);
+    return;
+  }
+
+  if (isMcpAppComponent(content)) {
+    collectMcpAppContent(draft, content, labels, language);
+    return;
+  }
+
+  const data = getToolStepData(content);
+  pushTag(
+    draft,
+    resolveLocalizedText(data.message, language) ??
+      getToolActivityLabel(content, language),
+  );
+  if (options.includeComponentText !== false) {
+    pushText(draft, resolveLocalizedText(data.message, language));
+    pushText(draft, resolveLocalizedText(data.title, language));
+    pushText(draft, resolveLocalizedText(data.tool, language));
+    pushText(draft, resolveLocalizedText(data.type, language));
+  }
+}
+
+function collectContentItem(
+  draft: NavigationDraft,
+  item: TMessageContentComplex | string | undefined,
+  labels: MessageNavigationLabels,
+  language: string,
+  options: CollectContentOptions,
+) {
+  if (item === undefined || isThreadContextUsageRenderArtifact(item)) return;
+  if (typeof item === 'string') {
+    pushText(draft, item);
+    return;
+  }
+
+  if (isTextContent(item) || isReasoningContent(item)) {
+    pushText(draft, item.text);
+    if (isReasoningContent(item)) pushTag(draft, labels.reasoning);
+    return;
+  }
+
+  if (item.type === 'image_url') {
+    pushTag(draft, labels.image);
+    return;
+  }
+
+  if (isComponentContent(item)) {
+    collectComponentContent(draft, item, labels, language, options);
+    return;
+  }
+
+  if (isMemoryContent(item)) {
+    pushTag(draft, labels.memory);
+  }
+}
+
+function collectContent(
+  draft: NavigationDraft,
+  content: unknown,
+  labels: MessageNavigationLabels,
+  language: string,
+  options: CollectContentOptions = {},
+) {
+  if (typeof content === 'string') {
+    pushText(draft, content);
+    return;
+  }
+
+  if (!Array.isArray(content)) {
+    return;
+  }
+
+  for (const item of content) {
+    collectContentItem(
+      draft,
+      item as TMessageContentComplex | string | undefined,
+      labels,
+      language,
+      options,
+    );
+  }
+}
+
+function collectReasoning(
+  draft: NavigationDraft,
+  reasoning: unknown,
+  labels: MessageNavigationLabels,
+) {
+  if (!Array.isArray(reasoning)) return;
+
+  for (const item of reasoning) {
+    if (!isRecord(item)) continue;
+    pushText(draft, item.text);
+    if (readString(item.text)) pushTag(draft, labels.reasoning);
+  }
+}
+
+function collectFiles(
+  draft: NavigationDraft,
+  value: unknown,
+  fallbackLabel: string,
+) {
+  if (!Array.isArray(value)) return;
+
+  for (const file of value) {
+    if (!isRecord(file)) continue;
+    pushTag(
+      draft,
+      file.originalName ??
+        file.name ??
+        file.fileName ??
+        file.id ??
+        fallbackLabel,
+    );
+  }
+}
+
+function collectReferences(draft: NavigationDraft, value: unknown) {
+  for (const reference of normalizeReferences(value) as ChatKitReference[]) {
+    pushTag(draft, getReferenceLabel(reference));
+  }
+}
+
+function collectRuntimeCapabilities(draft: NavigationDraft, value: unknown) {
+  if (!Array.isArray(value)) return;
+
+  for (const option of value as RuntimeCapabilityOptionLike[]) {
+    if (!isRecord(option)) continue;
+    pushTag(draft, option.label ?? option.id ?? option.type);
+  }
+}
+
+function getTitle(
+  role: MessageNavigationRole,
+  labels: MessageNavigationLabels,
+  assistantTitle?: string | null,
+) {
+  if (role === 'assistant' && assistantTitle?.trim()) {
+    return assistantTitle.trim();
+  }
+  return labels[role];
+}
+
+export function buildMessageNavigationItem(
+  message: MessageNavigationSourceMessage,
+  index: number,
+  options: BuildMessageNavigationItemsOptions,
+): MessageNavigationItem | null {
+  return buildMessageNavigationItemSummary(message, index, options);
+}
+
+function buildMessageNavigationItemSummary(
+  message: MessageNavigationSourceMessage,
+  index: number,
+  options: BuildMessageNavigationItemsOptions,
+  collectOptions: CollectContentOptions = {},
+): MessageNavigationItem | null {
+  const role = getMessageNavigationRole(message.type);
+  const draft: NavigationDraft = {
+    text: [],
+    tags: [],
+  };
+  const language = options.language ?? 'en-US';
+  const labels = options.labels;
+
+  if (role === 'user') {
+    pushText(draft, message.submittedInput);
+  }
+
+  collectContent(draft, message.content, labels, language, collectOptions);
+  collectReasoning(draft, message.reasoning, labels);
+  collectFiles(draft, message.fileAssets, labels.attachment);
+  collectFiles(draft, message.attachments, labels.attachment);
+  collectReferences(draft, message.references);
+  collectRuntimeCapabilities(draft, message.runtimeCapabilityOptions);
+
+  const text = draft.text.map(normalizeWhitespace).filter(Boolean).join(' ');
+  const preview =
+    truncate(text, MAX_PREVIEW_LENGTH) || draft.tags.slice(0, 2).join(' · ');
+
+  if (!preview && draft.tags.length === 0) {
+    return null;
+  }
+
+  const messageId = readString(message.id) ?? undefined;
+  return {
+    id: getMessageNavigationItemId(message, index),
+    ...(messageId ? { messageId } : {}),
+    index,
+    role,
+    title: getTitle(role, labels, options.assistantTitle),
+    preview,
+    tags: draft.tags,
+  };
+}
+
+export function buildMessageNavigationItems(
+  messages: MessageNavigationSourceMessage[],
+  options: BuildMessageNavigationItemsOptions,
+) {
+  const items: MessageNavigationItem[] = [];
+  let pendingUser: PendingUserNavigationItem | null = null;
+
+  messages.forEach((message, messageIndex) => {
+    const item = buildMessageNavigationItemSummary(
+      message,
+      messageIndex,
+      options,
+      { includeComponentText: false },
+    );
+    if (!item) return;
+
+    if (item.role === 'user') {
+      pendingUser = { item };
+      return;
+    }
+
+    if (item.role !== 'assistant' || !pendingUser) {
+      return;
+    }
+
+    items.push({
+      id: pendingUser.item.id,
+      ...(pendingUser.item.messageId
+        ? { messageId: pendingUser.item.messageId }
+        : {}),
+      index: items.length,
+      role: 'user',
+      title: pendingUser.item.preview,
+      preview: item.preview,
+      tags: mergeTags(item.tags, pendingUser.item.tags),
+    });
+    pendingUser = null;
+  });
+
+  return items;
+}

--- a/packages/chatkit/src/options.ts
+++ b/packages/chatkit/src/options.ts
@@ -335,6 +335,15 @@ export type ChatKitLayoutOptions = {
   maxWidth?: number | string;
 };
 
+export type ChatKitMessageNavigationOptions = {
+  /**
+   * Whether to show the message quick navigation rail.
+   *
+   * @default true
+   */
+  enabled?: boolean;
+};
+
 type CustomApiConfig = {
   /**
    * The URL (relative or absolute) of the ChatKit API. The configured endpoint
@@ -519,6 +528,11 @@ export type ChatKitOptions = {
    * Layout configuration for the ChatKit UI.
    */
   layout?: ChatKitLayoutOptions;
+
+  /**
+   * Message list quick navigation controls.
+   */
+  messageNavigation?: ChatKitMessageNavigationOptions;
 
   /**
    * Optional animated pet companion rendered by the ChatKit web component over


### PR DESCRIPTION
## Summary
- Add message navigation support to the chat UI, including previous/next controls and configurable navigation options.
- Add the `MessageNavigator` component and shared message-navigation utilities.
- Add English and Chinese locale strings, focused navigation tests, and a changeset for the UI package.

## Testing
- Not run locally; this PR was created from the existing remote `develop` branch.