### PR TITLE
[codex] Release runtime capabilities composer support

### DIFF
--- a/.changeset/swift-chefs-switch.md
+++ b/.changeset/swift-chefs-switch.md
@@ -1,0 +1,14 @@
+---
+'@xpert-ai/chatkit-web-shared': minor
+'@xpert-ai/chatkit-angular': minor
+'@xpert-ai/chatkit-react': minor
+'@xpert-ai/chatkit-web-component': minor
+'@xpert-ai/chatkit-vue2': minor
+'@xpert-ai/chatkit-ui5': minor
+'@xpert-ai/chatkit-vue': minor
+'@xpert-ai/chatkit-js': minor
+'@xpert-ai/chatkit-ui': patch
+'@xpert-ai/chatkit-types': patch
+---
+
+feat: set runtime capabilities

--- a/packages/chatkit-angular/src/control.ts
+++ b/packages/chatkit-angular/src/control.ts
@@ -9,6 +9,7 @@ const CHATKIT_METHOD_NAMES = Object.freeze([
   'setThreadId',
   'sendUserMessage',
   'setComposerValue',
+  'setRuntimeCapabilities',
   'fetchUpdates',
   'sendCustomAction',
 ] as const);
@@ -138,6 +139,12 @@ class ChatKitController {
 
   setComposerValue(...args: Parameters<XpertAIChatKit['setComposerValue']>) {
     return this.callMethod('setComposerValue', ...args);
+  }
+
+  setRuntimeCapabilities(
+    ...args: Parameters<XpertAIChatKit['setRuntimeCapabilities']>
+  ) {
+    return this.callMethod('setRuntimeCapabilities', ...args);
   }
 
   fetchUpdates(...args: Parameters<XpertAIChatKit['fetchUpdates']>) {

--- a/packages/chatkit-js/src/index.ts
+++ b/packages/chatkit-js/src/index.ts
@@ -31,6 +31,7 @@ const CHATKIT_METHOD_NAMES = Object.freeze([
   'setThreadId',
   'sendUserMessage',
   'setComposerValue',
+  'setRuntimeCapabilities',
   'fetchUpdates',
   'sendCustomAction',
 ] as const);
@@ -141,7 +142,9 @@ export type ChatKitInstance = ChatKitMethods & {
   destroy: () => void;
 };
 
-export function createChatKit(config: CreateChatKitOptions = {}): ChatKitInstance {
+export function createChatKit(
+  config: CreateChatKitOptions = {} as CreateChatKitOptions,
+): ChatKitInstance {
   const element = resolveElement(config.element ?? null);
   const { options, handlers } = splitOptions(config);
 
@@ -163,7 +166,7 @@ export function createChatKit(config: CreateChatKitOptions = {}): ChatKitInstanc
     );
   }
 
-  const methods = {} as ChatKitMethods;
+  const methods = {} as Record<ChatKitMethod, (...args: any[]) => unknown>;
   for (const key of CHATKIT_METHOD_NAMES) {
     methods[key] = (...args: any[]) => {
       const method = element[key];
@@ -189,6 +192,6 @@ export function createChatKit(config: CreateChatKitOptions = {}): ChatKitInstanc
   return {
     element,
     destroy,
-    ...methods,
+    ...(methods as ChatKitMethods),
   };
 }

--- a/packages/chatkit-react/src/useChatKit.ts
+++ b/packages/chatkit-react/src/useChatKit.ts
@@ -12,6 +12,7 @@ const CHATKIT_METHOD_NAMES = Object.freeze([
   'setThreadId',
   'sendUserMessage',
   'setComposerValue',
+  'setRuntimeCapabilities',
   'fetchUpdates',
   'sendCustomAction',
 ] as const);

--- a/packages/chatkit-ui/src/components/chat.plan-mode.test.tsx
+++ b/packages/chatkit-ui/src/components/chat.plan-mode.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -77,6 +78,9 @@ const mocks = vi.hoisted(() => {
       stopRuntimeActivityItem: vi.fn(),
       setThreadId: vi.fn(),
     },
+    parentMessengerOptions: null as null | {
+      onSetComposerValue?: (payload: unknown) => void;
+    },
   };
 });
 
@@ -133,7 +137,14 @@ vi.mock('../providers/Theme', () => ({
 }));
 
 vi.mock('../hooks/useParentMessenger', () => ({
-  useParentMessenger: () => undefined,
+  useParentMessenger: (options?: {
+    onSetComposerValue?: (payload: unknown) => void;
+  }) => {
+    if (options?.onSetComposerValue) {
+      mocks.parentMessengerOptions = options;
+    }
+    return undefined;
+  },
 }));
 
 vi.mock('./composer/ComposerMenu', () => ({
@@ -488,6 +499,7 @@ describe('Chat plan mode payload', () => {
     mocks.stream.error = null;
     mocks.stream.submit.mockResolvedValue(undefined);
     (mocks.stream as { threadGoal?: ThreadGoal | null }).threadGoal = null;
+    mocks.parentMessengerOptions = null;
   });
 
   afterEach(() => {
@@ -2087,6 +2099,77 @@ describe('Chat plan mode payload', () => {
       skills: { ids: [] },
       plugins: { nodeKeys: [] },
       subAgents: { nodeKeys: [] },
+    });
+  });
+
+  it('inserts parent-requested runtime capabilities as atomic composer tokens', async () => {
+    mocks.stream.client.assistants.getRuntimeCapabilities.mockResolvedValueOnce(
+      {
+        skills: [
+          {
+            id: 'skill-docs',
+            workspaceId: 'workspace-1',
+            label: 'documents',
+            repositoryName: 'Documents',
+          },
+        ],
+        plugins: [],
+        subAgents: [],
+      },
+    );
+
+    renderChat();
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('runtime-capabilities-ready'),
+      ).toHaveTextContent('ready'),
+    );
+
+    expect(mocks.parentMessengerOptions?.onSetComposerValue).toEqual(
+      expect.any(Function),
+    );
+    await act(async () => {
+      mocks.parentMessengerOptions?.onSetComposerValue?.({
+        runtimeCapabilities: {
+          mode: 'allowlist',
+          skills: { workspaceId: 'workspace-1', ids: ['skill-docs'] },
+          plugins: { nodeKeys: [] },
+          subAgents: { nodeKeys: [] },
+        },
+        insertRuntimeCapabilities: true,
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByRole('textbox')).getByText('documents'),
+      ).toBeInTheDocument(),
+    );
+
+    let textbox = screen.getByRole('textbox');
+    expect(
+      textbox.querySelector('[data-composer-capability-key]'),
+    ).toHaveAttribute('data-capability-id', 'skill-docs');
+
+    textbox = insertComposerText(textbox, ' create a doc');
+    const send = screen.getByRole('button', { name: 'send' });
+    await waitFor(() => expect(send).not.toBeDisabled());
+    fireEvent.click(send);
+
+    await waitFor(() => expect(mocks.stream.submit).toHaveBeenCalledTimes(1));
+    expect(
+      mocks.stream.submit.mock.calls[0][0].input.runtimeCapabilities,
+    ).toEqual({
+      mode: 'allowlist',
+      skills: { workspaceId: 'workspace-1', ids: ['skill-docs'] },
+      plugins: { nodeKeys: [] },
+      subAgents: { nodeKeys: [] },
+      recommended: {
+        skills: { workspaceId: 'workspace-1', ids: ['skill-docs'] },
+        plugins: { nodeKeys: [] },
+        subAgents: { nodeKeys: [] },
+      },
     });
   });
 

--- a/packages/chatkit-ui/src/components/chat.tsx
+++ b/packages/chatkit-ui/src/components/chat.tsx
@@ -75,7 +75,6 @@ import {
   type ChatkitAvatarData,
   extractAssistantAvatar,
 } from './ui/chatkit-avatar';
-import { RuntimeCapabilityIcon } from './runtime-capability-icon';
 import { useStreamManager } from '../hooks/useStream';
 import { useThreads } from '../hooks/useThreads';
 import { useChatkitTranslation } from '../i18n/useChatkitTranslation';
@@ -109,23 +108,10 @@ import {
   type PetLocalSettings,
 } from './pet/pet-local-settings';
 import {
-  createEmptyRuntimeCapabilitiesSelection,
-  createDefaultRuntimeCapabilitiesSelection,
-  createRuntimeCapabilitiesForSubmit,
   getRecommendedRuntimeCapabilitiesSelection,
-  getRuntimeCapabilityOptions,
-  isRuntimeCapabilitySelected,
-  mergeRuntimeCapabilitiesSelections,
-  toggleRuntimeCapabilitySelection,
   type RuntimeCapabilitiesSelection,
   type RuntimeCapabilityOption,
 } from '../lib/runtime-capabilities';
-import {
-  hasMissingRuntimeCapabilityReferences,
-  loadConversationRuntimeCapabilities,
-  persistConversationRuntimeCapabilities as persistRuntimeCapabilitiesToConversation,
-  type MissingRuntimeCapabilityReferences,
-} from '../lib/conversation-runtime-capabilities';
 import {
   executeThreadGoalCommand,
   loadThreadGoal,
@@ -136,32 +122,31 @@ import {
   supportsXpertThreadGoalAdapter,
 } from '../lib/xpert-thread-goal-adapter';
 import {
-  createComposerCapabilityPart,
   createComposerTextParts,
   findAdjacentComposerCapability,
-  getComposerCapabilityKeys,
   getComposerCapabilityPartMap,
-  getComposerCapabilitySelectionKeys,
   getComposerEditingLength,
-  getComposerEditingText,
   getComposerPlainText,
   getComposerSelectionOffset,
   getComposerSelectionOffsets,
-  getRuntimeCapabilityOptionKey,
   normalizeComposerParts,
   readComposerPartsFromElement,
-  removeComposerCapabilityTokens,
   replaceComposerRange,
   setComposerSelectionOffset,
-  type ComposerCapabilityPart,
   type ComposerPart,
 } from '../lib/composer-parts';
+import { hasSelectedRuntimeSlashCommand } from '../lib/slash-commands';
 import {
-  hasSelectedRuntimeSlashCommand,
-  resolveRuntimeCapabilityPalette,
-  type RuntimeCapabilitiesWithCommands,
-  type RuntimeCapabilityPaletteState,
-} from '../lib/slash-commands';
+  ComposerCapabilityToken,
+  DetachedRunRuntimeCapabilities,
+  HumanRuntimeCapabilityChips,
+  getRemovedComposerCapabilityParts,
+  getRuntimeCapabilityOptionsForSelection,
+  getRuntimeCapabilityPaletteEmptyLabelKey,
+  removeComposerCapabilityPartsFromSelection,
+  useRuntimeCapabilitiesState,
+  useRuntimeCapabilityComposerActions,
+} from './chat/runtime-capabilities';
 import {
   buildMessageNavigationItems,
   getMessageNavigationItemId,
@@ -219,37 +204,6 @@ type HumanMessageWithMeta = Message & {
   runtimeCapabilityOptions?: RuntimeCapabilityOption[];
 };
 
-function getSlashPaletteEmptyLabelKey(
-  palette: RuntimeCapabilityPaletteState,
-  runtimeCapabilitiesReady: boolean,
-): string {
-  if (!palette.capabilityTypes || palette.capabilityTypes.length !== 1) {
-    return 'composer.capabilities.emptySearch';
-  }
-
-  if (!runtimeCapabilitiesReady) {
-    return 'composer.slashCommands.empty.loadingCapabilities';
-  }
-
-  const hasQuery = palette.query.trim().length > 0;
-  const capabilityType = palette.capabilityTypes[0];
-  if (capabilityType === 'skill') {
-    return hasQuery
-      ? 'composer.slashCommands.empty.matchingSkills'
-      : 'composer.slashCommands.empty.skills';
-  }
-
-  if (capabilityType === 'plugin') {
-    return hasQuery
-      ? 'composer.slashCommands.empty.matchingPlugins'
-      : 'composer.slashCommands.empty.plugins';
-  }
-
-  return hasQuery
-    ? 'composer.slashCommands.empty.matchingSubAgents'
-    : 'composer.slashCommands.empty.subAgents';
-}
-
 type QuoteSelectionState = {
   reference: ChatKitReference;
   top: number;
@@ -263,42 +217,6 @@ type SubmitDraftOptions = {
   runtimeCapabilities?: RuntimeCapabilitiesSelection;
   planMode?: boolean;
 };
-
-function getHttpStatus(error: unknown): number | null {
-  if (!error || typeof error !== 'object' || !('status' in error)) {
-    return null;
-  }
-
-  const status = (error as { status?: unknown }).status;
-  return typeof status === 'number' ? status : null;
-}
-
-function warnMissingRuntimeCapabilityReferences(
-  action: string,
-  missing: MissingRuntimeCapabilityReferences,
-) {
-  if (!hasMissingRuntimeCapabilityReferences(missing)) {
-    return;
-  }
-
-  console.warn(
-    `[Chat] Runtime capabilities ${action} include unavailable references:`,
-    missing,
-  );
-}
-
-function getSelectedRuntimeCapabilityOptions(
-  selection: RuntimeCapabilitiesSelection | null | undefined,
-  options: RuntimeCapabilityOption[],
-): RuntimeCapabilityOption[] {
-  if (!selection) {
-    return [];
-  }
-
-  return options.filter((option) =>
-    isRuntimeCapabilitySelected(selection, option.type, option.id),
-  );
-}
 
 async function readImageDimensions(file: File): Promise<{
   width?: number;
@@ -507,6 +425,38 @@ export function Chat({
   const { setStream } = useStreamManager();
   const stream = useStreamContext();
   const { theme } = useTheme();
+  const effectiveClientSecret = stream.apiKey?.trim()
+    ? stream.apiKey
+    : clientSecret;
+  const missingConfigKind = getMissingApiConfigurationKind({
+    apiUrl,
+    clientSecret: effectiveClientSecret,
+  });
+  const missingConfig = Boolean(missingConfigKind);
+  const missingConfigShortMessage = React.useMemo(() => {
+    switch (missingConfigKind) {
+      case 'apiUrl':
+        return t('chat.missingApiUrlShort');
+      case 'clientSecret':
+        return t('chat.missingClientSecretShort');
+      case 'apiUrlAndClientSecret':
+        return t('chat.missingApiUrlAndClientSecretShort');
+      default:
+        return t('chat.missingConfigShort');
+    }
+  }, [missingConfigKind, t]);
+  const missingConfigDetailMessage = React.useMemo(() => {
+    switch (missingConfigKind) {
+      case 'apiUrl':
+        return t('chat.missingApiUrlDetail');
+      case 'clientSecret':
+        return t('chat.missingClientSecretDetail');
+      case 'apiUrlAndClientSecret':
+        return t('chat.missingApiUrlAndClientSecretDetail');
+      default:
+        return t('chat.missingConfigDetail');
+    }
+  }, [missingConfigKind, t]);
 
   const [isHistoryLoading, setIsHistoryLoading] = React.useState(false);
   const [historyError, setHistoryError] = React.useState<string | null>(null);
@@ -618,20 +568,6 @@ export function Chat({
   const [petSettingsOpen, setPetSettingsOpen] = React.useState(false);
   const [petLocalSettings, setPetLocalSettings] =
     React.useState<PetLocalSettings | null>(() => readPetLocalSettings());
-  const [runtimeCapabilities, setRuntimeCapabilities] =
-    React.useState<RuntimeCapabilitiesWithCommands | null>(null);
-  const [runtimeCapabilitiesReady, setRuntimeCapabilitiesReady] =
-    React.useState(false);
-  const [sessionRuntimeCapabilities, setSessionRuntimeCapabilities] =
-    React.useState<RuntimeCapabilitiesSelection>(() =>
-      createEmptyRuntimeCapabilitiesSelection(),
-    );
-  const [runRuntimeCapabilities, setRunRuntimeCapabilities] =
-    React.useState<RuntimeCapabilitiesSelection>(() =>
-      createEmptyRuntimeCapabilitiesSelection(),
-    );
-  const [runtimeCapabilityPalette, setRuntimeCapabilityPalette] =
-    React.useState<RuntimeCapabilityPaletteState | null>(null);
   const [attachmentState, setAttachmentState] =
     React.useState<ChatAttachmentsState>({
       uploadedFiles: [],
@@ -671,7 +607,30 @@ export function Chat({
   const autoScrollFrameRef = React.useRef<number | null>(null);
   const isPointerDownRef = React.useRef(false);
   const lastTouchYRef = React.useRef<number | null>(null);
-  const runtimeCapabilityPreferenceLoadRef = React.useRef(0);
+  const {
+    runtimeCapabilities,
+    runtimeCapabilitiesReady,
+    runtimeCapabilityOptions,
+    effectiveSessionRuntimeCapabilities,
+    runRuntimeCapabilities,
+    detachedRunRuntimeCapabilityOptions,
+    runtimeCapabilityPalette,
+    setRunRuntimeCapabilities,
+    setRuntimeCapabilityPalette,
+    applyExternalRuntimeCapabilities,
+    handleSessionRuntimeCapabilityToggle,
+    addRunRuntimeCapabilities,
+    resetRunRuntimeCapabilities,
+    getRuntimeCapabilitiesForSubmit,
+    getRuntimeCapabilitiesForCommand,
+    persistSessionRuntimeCapabilities,
+  } = useRuntimeCapabilitiesState({
+    client: stream.client,
+    assistantId: stream.assistantId,
+    threadId: stream.threadId,
+    disabled: missingConfig || !stream.client || !stream.assistantId,
+    composerParts,
+  });
 
   const resolvedTitle = title ?? t('chat.title');
   const resolvedPlaceholder = placeholder ?? t('chat.placeholder');
@@ -811,10 +770,6 @@ export function Chat({
   const hasPendingInteractiveRequest =
     hasPendingRequestUserInput || hasPendingHITLRequest;
   const hasPendingTodos = Boolean(stream.todos?.items.length);
-  const runtimeCapabilityOptions = React.useMemo(
-    () => getRuntimeCapabilityOptions(runtimeCapabilities),
-    [runtimeCapabilities],
-  );
   const goalAdapter = React.useMemo<ChatKitGoalAdapter | null>(() => {
     if (isGoalAdapter(options?.goal)) {
       return options.goal;
@@ -829,16 +784,6 @@ export function Chat({
         ? Math.max(0, Math.floor((streamingNow - goalElapsedStartedAt) / 1000))
         : 0)
     : 0;
-  const effectiveSessionRuntimeCapabilities = React.useMemo(
-    () =>
-      runtimeCapabilitiesReady && runtimeCapabilities
-        ? mergeRuntimeCapabilitiesSelections(
-            runtimeCapabilities,
-            sessionRuntimeCapabilities,
-          )
-        : null,
-    [runtimeCapabilities, runtimeCapabilitiesReady, sessionRuntimeCapabilities],
-  );
   const goalCommandAvailable = hasSelectedRuntimeSlashCommand(
     runtimeCapabilities,
     effectiveSessionRuntimeCapabilities,
@@ -849,61 +794,6 @@ export function Chat({
     !hasCompletedGoal &&
     (Boolean(goalError) ||
       (threadGoal?.status === 'active' && stream.isLoading));
-  const runRuntimeCapabilityOptions = React.useMemo(
-    () =>
-      runtimeCapabilityOptions.filter((option) =>
-        isRuntimeCapabilitySelected(
-          runRuntimeCapabilities,
-          option.type,
-          option.id,
-        ),
-      ),
-    [runRuntimeCapabilities, runtimeCapabilityOptions],
-  );
-  const composerRuntimeCapabilitySelectionKeys = React.useMemo(
-    () => getComposerCapabilitySelectionKeys(composerParts),
-    [composerParts],
-  );
-  const detachedRunRuntimeCapabilityOptions = React.useMemo(
-    () =>
-      runRuntimeCapabilityOptions.filter(
-        (option) =>
-          !composerRuntimeCapabilitySelectionKeys.has(
-            getRuntimeCapabilityOptionKey(option),
-          ),
-      ),
-    [composerRuntimeCapabilitySelectionKeys, runRuntimeCapabilityOptions],
-  );
-
-  const persistSessionRuntimeCapabilities = React.useCallback(
-    async (
-      threadId: string,
-      selection: RuntimeCapabilitiesSelection | null | undefined,
-    ) => {
-      if (!runtimeCapabilities || !selection) {
-        return;
-      }
-
-      try {
-        const result = await persistRuntimeCapabilitiesToConversation({
-          client: stream.client,
-          threadId,
-          capabilities: runtimeCapabilities,
-          selection,
-        });
-        warnMissingRuntimeCapabilityReferences(
-          'persisted selection',
-          result.missing,
-        );
-      } catch (error) {
-        console.warn(
-          '[Chat] Failed to persist runtime capabilities selection:',
-          error,
-        );
-      }
-    },
-    [runtimeCapabilities, stream.client],
-  );
 
   const clearQuoteSelection = React.useCallback(() => {
     setQuoteSelection(null);
@@ -927,25 +817,18 @@ export function Chat({
       }
 
       if (options?.syncRemovedCapabilityTokens ?? true) {
-        const nextKeys = getComposerCapabilityKeys(normalized);
-        const removedCapabilities = previous.filter(
-          (part): part is ComposerCapabilityPart =>
-            part.type === 'capability' && !nextKeys.has(part.key),
+        const removedCapabilities = getRemovedComposerCapabilityParts(
+          previous,
+          normalized,
         );
 
         if (removedCapabilities.length > 0) {
-          setRunRuntimeCapabilities((selection) => {
-            let nextSelection = selection;
-            for (const part of removedCapabilities) {
-              nextSelection = toggleRuntimeCapabilitySelection(
-                nextSelection,
-                part.capability.type,
-                part.capability.id,
-                false,
-              );
-            }
-            return nextSelection;
-          });
+          setRunRuntimeCapabilities((selection) =>
+            removeComposerCapabilityPartsFromSelection(
+              selection,
+              removedCapabilities,
+            ),
+          );
         }
       }
 
@@ -955,7 +838,7 @@ export function Chat({
         setComposerDomVersion((version) => version + 1);
       }
     },
-    [],
+    [setRunRuntimeCapabilities],
   );
 
   const setComposerText = React.useCallback(
@@ -981,6 +864,24 @@ export function Chat({
       setComposerSelectionOffset(input, nextPosition);
     });
   }, []);
+
+  const {
+    applyComposerValueRuntimeCapabilities,
+    updateRuntimeCapabilityPalette,
+    removeRunRuntimeCapability,
+    insertComposerCapabilityToken,
+  } = useRuntimeCapabilityComposerActions({
+    runtimeCapabilities,
+    runtimeCapabilitiesReady,
+    runtimeCapabilityOptions,
+    setRunRuntimeCapabilities,
+    setRuntimeCapabilityPalette,
+    applyExternalRuntimeCapabilities,
+    composerInputRef,
+    composerPartsRef,
+    commitComposerParts,
+    focusComposerAt,
+  });
 
   const parentMessenger = useParentMessenger({
     onSetComposerValue: React.useCallback(
@@ -1011,8 +912,20 @@ export function Chat({
                 ) ?? null);
           setSelectedTool(nextTool);
         }
+
+        applyComposerValueRuntimeCapabilities(payload);
       },
-      [composer?.tools, setComposerText],
+      [
+        applyComposerValueRuntimeCapabilities,
+        composer?.tools,
+        setComposerText,
+      ],
+    ),
+    onSetRuntimeCapabilities: React.useCallback(
+      (selection: RuntimeCapabilitiesSelection | null) => {
+        applyExternalRuntimeCapabilities(selection);
+      },
+      [applyExternalRuntimeCapabilities],
     ),
     onFocusComposer: React.useCallback(() => {
       composerInputRef.current?.focus();
@@ -1303,38 +1216,6 @@ export function Chat({
     }
   }, [stream.isLoading, messages, scrollToBottom]);
 
-  const effectiveClientSecret = stream.apiKey?.trim()
-    ? stream.apiKey
-    : clientSecret;
-  const missingConfigKind = getMissingApiConfigurationKind({
-    apiUrl,
-    clientSecret: effectiveClientSecret,
-  });
-  const missingConfig = Boolean(missingConfigKind);
-  const missingConfigShortMessage = React.useMemo(() => {
-    switch (missingConfigKind) {
-      case 'apiUrl':
-        return t('chat.missingApiUrlShort');
-      case 'clientSecret':
-        return t('chat.missingClientSecretShort');
-      case 'apiUrlAndClientSecret':
-        return t('chat.missingApiUrlAndClientSecretShort');
-      default:
-        return t('chat.missingConfigShort');
-    }
-  }, [missingConfigKind, t]);
-  const missingConfigDetailMessage = React.useMemo(() => {
-    switch (missingConfigKind) {
-      case 'apiUrl':
-        return t('chat.missingApiUrlDetail');
-      case 'clientSecret':
-        return t('chat.missingClientSecretDetail');
-      case 'apiUrlAndClientSecret':
-        return t('chat.missingApiUrlAndClientSecretDetail');
-      default:
-        return t('chat.missingConfigDetail');
-    }
-  }, [missingConfigKind, t]);
   const showMissingConfig = !isClientSecretInitializing && missingConfig;
   // File parsing can continue after submit; only the transport upload blocks send.
   const hasUploadingFiles = attachmentState.hasUploadingFiles;
@@ -1446,126 +1327,6 @@ export function Chat({
   }, [missingConfig, stream.client, stream.assistantId]);
 
   React.useEffect(() => {
-    if (missingConfig || !stream.client || !stream.assistantId) {
-      setRuntimeCapabilities(null);
-      setRuntimeCapabilitiesReady(false);
-      setSessionRuntimeCapabilities(createEmptyRuntimeCapabilitiesSelection());
-      setRunRuntimeCapabilities(createEmptyRuntimeCapabilitiesSelection());
-      setRuntimeCapabilityPalette(null);
-      return;
-    }
-
-    const controller = new AbortController();
-
-    setRuntimeCapabilitiesReady(false);
-    setRuntimeCapabilities(null);
-    setRuntimeCapabilityPalette(null);
-
-    void stream.client.assistants
-      .getRuntimeCapabilities(stream.assistantId, {
-        signal: controller.signal,
-      })
-      .then((payload) => {
-        setRuntimeCapabilities(payload);
-        setRuntimeCapabilitiesReady(true);
-        setSessionRuntimeCapabilities(
-          createDefaultRuntimeCapabilitiesSelection(payload),
-        );
-        setRunRuntimeCapabilities(
-          createEmptyRuntimeCapabilitiesSelection(payload),
-        );
-      })
-      .catch((error: unknown) => {
-        if (controller.signal.aborted) {
-          return;
-        }
-        if (getHttpStatus(error) === 404) {
-          setRuntimeCapabilities(null);
-          setRuntimeCapabilitiesReady(false);
-          setSessionRuntimeCapabilities(
-            createEmptyRuntimeCapabilitiesSelection(),
-          );
-          setRunRuntimeCapabilities(createEmptyRuntimeCapabilitiesSelection());
-          return;
-        }
-        console.warn('[Chat] Failed to load runtime capabilities:', error);
-        setRuntimeCapabilities(null);
-        setRuntimeCapabilitiesReady(false);
-        setSessionRuntimeCapabilities(
-          createEmptyRuntimeCapabilitiesSelection(),
-        );
-        setRunRuntimeCapabilities(createEmptyRuntimeCapabilitiesSelection());
-      });
-
-    return () => controller.abort();
-  }, [missingConfig, stream.client, stream.assistantId]);
-
-  React.useEffect(() => {
-    setRunRuntimeCapabilities(
-      createEmptyRuntimeCapabilitiesSelection(runtimeCapabilities),
-    );
-
-    if (!runtimeCapabilitiesReady || !runtimeCapabilities) {
-      setSessionRuntimeCapabilities(
-        createEmptyRuntimeCapabilitiesSelection(runtimeCapabilities),
-      );
-      return;
-    }
-
-    const defaultSelection =
-      createDefaultRuntimeCapabilitiesSelection(runtimeCapabilities);
-    const threadId = stream.threadId?.trim();
-    if (!threadId) {
-      setSessionRuntimeCapabilities(defaultSelection);
-      return;
-    }
-
-    let cancelled = false;
-    const requestId = runtimeCapabilityPreferenceLoadRef.current + 1;
-    runtimeCapabilityPreferenceLoadRef.current = requestId;
-    setSessionRuntimeCapabilities(defaultSelection);
-
-    void loadConversationRuntimeCapabilities({
-      client: stream.client,
-      threadId,
-      capabilities: runtimeCapabilities,
-    })
-      .then(({ selection, missing }) => {
-        if (
-          cancelled ||
-          runtimeCapabilityPreferenceLoadRef.current !== requestId
-        ) {
-          return;
-        }
-
-        warnMissingRuntimeCapabilityReferences('loaded selection', missing);
-        setSessionRuntimeCapabilities(selection ?? defaultSelection);
-      })
-      .catch((error: unknown) => {
-        if (
-          cancelled ||
-          runtimeCapabilityPreferenceLoadRef.current !== requestId
-        ) {
-          return;
-        }
-        console.warn(
-          '[Chat] Failed to load persisted runtime capabilities selection:',
-          error,
-        );
-        setSessionRuntimeCapabilities(defaultSelection);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    runtimeCapabilities,
-    runtimeCapabilitiesReady,
-    stream.client,
-    stream.threadId,
-  ]);
-
-  React.useEffect(() => {
     setThreadGoal(stream.threadGoal);
   }, [stream.threadGoal]);
 
@@ -1620,44 +1381,6 @@ export function Chat({
   // are fetched later by built-in file-understanding tools.
   const uploadedFiles = attachmentState.uploadedFiles;
 
-  const handleSessionRuntimeCapabilityToggle = React.useCallback(
-    (type: RuntimeCapabilityOption['type'], id: string, selected: boolean) => {
-      setSessionRuntimeCapabilities((previous) => {
-        const nextSelection = toggleRuntimeCapabilitySelection(
-          previous,
-          type,
-          id,
-          selected,
-        );
-
-        const threadId = stream.threadId?.trim();
-        if (threadId) {
-          void persistSessionRuntimeCapabilities(threadId, nextSelection);
-        }
-
-        return nextSelection;
-      });
-    },
-    [persistSessionRuntimeCapabilities, stream.threadId],
-  );
-
-  const updateRuntimeCapabilityPalette = React.useCallback(
-    (parts: ComposerPart[], selectionStart?: number | null) => {
-      const input = composerInputRef.current;
-      const editingText = getComposerEditingText(parts);
-      const nextPalette = resolveRuntimeCapabilityPalette(
-        editingText,
-        typeof selectionStart === 'number'
-          ? selectionStart
-          : input
-            ? getComposerSelectionOffset(input)
-            : getComposerEditingLength(parts),
-      );
-      setRuntimeCapabilityPalette(nextPalette);
-    },
-    [],
-  );
-
   const syncComposerInputFromElement = React.useCallback(
     (input: HTMLDivElement) => {
       const previousCapabilities = getComposerCapabilityPartMap(
@@ -1702,27 +1425,6 @@ export function Chat({
     );
   }, [updateRuntimeCapabilityPalette]);
 
-  const removeRunRuntimeCapability = React.useCallback(
-    (option: RuntimeCapabilityOption) => {
-      setRunRuntimeCapabilities((previous) =>
-        toggleRuntimeCapabilitySelection(
-          previous,
-          option.type,
-          option.id,
-          false,
-        ),
-      );
-      commitComposerParts(
-        removeComposerCapabilityTokens(composerPartsRef.current, option),
-        {
-          resetDom: true,
-          syncRemovedCapabilityTokens: false,
-        },
-      );
-    },
-    [commitComposerParts],
-  );
-
   const submitDraft = React.useCallback(
     (submitOptions: SubmitDraftOptions = {}) => {
       if (isSubmissionBlocked) return;
@@ -1743,31 +1445,10 @@ export function Chat({
         return;
       }
 
-      const recommendedRuntimeCapabilitiesForSubmit =
-        submitOptions.runtimeCapabilities &&
-        runtimeCapabilities &&
-        runtimeCapabilitiesReady
-          ? mergeRuntimeCapabilitiesSelections(
-              runtimeCapabilities,
-              runRuntimeCapabilities,
-              submitOptions.runtimeCapabilities,
-            )
-          : runRuntimeCapabilities;
-      const runtimeCapabilitiesForSubmit =
-        runtimeCapabilities && runtimeCapabilitiesReady
-          ? createRuntimeCapabilitiesForSubmit({
-              capabilities: runtimeCapabilities,
-              available: effectiveSessionRuntimeCapabilities,
-              recommended: recommendedRuntimeCapabilitiesForSubmit,
-            })
-          : null;
-      const runtimeCapabilityOptionsForMessage =
-        getSelectedRuntimeCapabilityOptions(
-          getRecommendedRuntimeCapabilitiesSelection(
-            runtimeCapabilitiesForSubmit,
-          ),
-          runtimeCapabilityOptions,
-        );
+      const {
+        runtimeCapabilitiesForSubmit,
+        runtimeCapabilityOptionsForMessage,
+      } = getRuntimeCapabilitiesForSubmit(submitOptions.runtimeCapabilities);
 
       const displayContent =
         submitOptions.displayText ||
@@ -1870,21 +1551,16 @@ export function Chat({
       }
       attachmentsRef.current?.clear();
       setReferences([]);
-      setRunRuntimeCapabilities(
-        createEmptyRuntimeCapabilitiesSelection(runtimeCapabilities),
-      );
-      setRuntimeCapabilityPalette(null);
+      resetRunRuntimeCapabilities();
     },
     [
       effectiveSessionRuntimeCapabilities,
+      getRuntimeCapabilitiesForSubmit,
       isSubmissionBlocked,
       options?.request,
       persistSessionRuntimeCapabilities,
       references,
-      runtimeCapabilities,
-      runtimeCapabilitiesReady,
-      runtimeCapabilityOptions,
-      runRuntimeCapabilities,
+      resetRunRuntimeCapabilities,
       scrollToBottom,
       selectedTool,
       commitComposerParts,
@@ -1954,13 +1630,7 @@ export function Chat({
         if (startsGoalRun) {
           const goalRunThreadId = result.threadId ?? threadId;
           const runtimeCapabilitiesForGoalRun =
-            runtimeCapabilities && runtimeCapabilitiesReady
-              ? createRuntimeCapabilitiesForSubmit({
-                  capabilities: runtimeCapabilities,
-                  available: effectiveSessionRuntimeCapabilities,
-                  recommended: commandRuntimeCapabilities,
-                })
-              : (commandRuntimeCapabilities ?? null);
+            getRuntimeCapabilitiesForCommand(commandRuntimeCapabilities);
           const inputPayload: {
             input: string;
             runtimeCapabilities?: RuntimeCapabilitiesSelection;
@@ -2035,12 +1705,10 @@ export function Chat({
       }
     },
     [
-      effectiveSessionRuntimeCapabilities,
+      getRuntimeCapabilitiesForCommand,
       goalAdapter,
       options?.request,
       refreshThreads,
-      runtimeCapabilities,
-      runtimeCapabilitiesReady,
       stream,
       t,
     ],
@@ -2049,57 +1717,6 @@ export function Chat({
   const handleGoalPanelOpenChange = React.useCallback((open: boolean) => {
     setIsGoalPanelOpen(open);
   }, []);
-
-  const addRunRuntimeCapabilities = React.useCallback(
-    (selection: RuntimeCapabilitiesSelection) => {
-      setRunRuntimeCapabilities((previous) =>
-        runtimeCapabilities
-          ? mergeRuntimeCapabilitiesSelections(
-              runtimeCapabilities,
-              previous,
-              selection,
-            )
-          : previous,
-      );
-    },
-    [runtimeCapabilities],
-  );
-
-  const insertComposerCapabilityToken = React.useCallback(
-    (
-      capability: RuntimeCapabilityOption,
-      range?: { start: number; end: number },
-    ) => {
-      const token = createComposerCapabilityPart(capability, createMessageId());
-      const currentParts = composerPartsRef.current;
-      const replaceRange = range ?? {
-        start: getComposerEditingLength(currentParts),
-        end: getComposerEditingLength(currentParts),
-      };
-      const nextParts = replaceComposerRange(
-        currentParts,
-        replaceRange.start,
-        replaceRange.end,
-        [token],
-      );
-      commitComposerParts(nextParts, {
-        caretOffset: replaceRange.start + 1,
-        resetDom: true,
-        syncRemovedCapabilityTokens: true,
-      });
-      setRunRuntimeCapabilities((previous) =>
-        toggleRuntimeCapabilitySelection(
-          previous,
-          capability.type,
-          capability.id,
-          true,
-        ),
-      );
-      setRuntimeCapabilityPalette(null);
-      focusComposerAt(replaceRange.start + 1);
-    },
-    [commitComposerParts, focusComposerAt],
-  );
 
   const {
     slashPaletteOptions,
@@ -2130,7 +1747,7 @@ export function Chat({
   });
   const slashPaletteEmptyLabel = runtimeCapabilityPalette
     ? t(
-        getSlashPaletteEmptyLabelKey(
+        getRuntimeCapabilityPaletteEmptyLabelKey(
           runtimeCapabilityPalette,
           runtimeCapabilitiesReady,
         ),
@@ -3085,7 +2702,7 @@ export function Chat({
               const humanRuntimeCapabilityOptions =
                 message.type === 'human'
                   ? (humanMessage.runtimeCapabilityOptions ??
-                    getSelectedRuntimeCapabilityOptions(
+                    getRuntimeCapabilityOptionsForSelection(
                       getRecommendedRuntimeCapabilitiesSelection(
                         humanMessage.runtimeCapabilities,
                       ),
@@ -3175,22 +2792,9 @@ export function Chat({
                         <>
                           {message.type === 'human' &&
                             humanRuntimeCapabilityOptions.length > 0 && (
-                              <div className="mb-2 flex flex-wrap gap-1.5">
-                                {humanRuntimeCapabilityOptions.map((option) => (
-                                  <span
-                                    key={`${option.type}:${option.id}`}
-                                    className="inline-flex max-w-full items-center gap-1 rounded-md bg-primary-foreground/20 px-2 py-1 text-xs font-medium text-primary-foreground"
-                                  >
-                                    <RuntimeCapabilityIcon
-                                      option={option}
-                                      variant="chip"
-                                    />
-                                    <span className="max-w-[9rem] truncate">
-                                      {option.label}
-                                    </span>
-                                  </span>
-                                ))}
-                              </div>
+                              <HumanRuntimeCapabilityChips
+                                options={humanRuntimeCapabilityOptions}
+                              />
                             )}
                           {message.type === 'human' &&
                             humanReferences.length > 0 && (
@@ -3385,31 +2989,12 @@ export function Chat({
           </div>
         )}
 
-        {detachedRunRuntimeCapabilityOptions.length > 0 && (
-          <div className="mb-2 flex flex-wrap items-center gap-2">
-            <span className="text-xs text-muted-foreground">
-              {t('composer.capabilities.runOnly')}
-            </span>
-            {detachedRunRuntimeCapabilityOptions.map((option) => (
-              <span
-                key={`${option.type}:${option.id}`}
-                className="inline-flex max-w-full items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
-              >
-                <RuntimeCapabilityIcon option={option} variant="chip" />
-                <span className="max-w-40 truncate">{option.label}</span>
-                <button
-                  type="button"
-                  onClick={() => removeRunRuntimeCapability(option)}
-                  className="rounded-full p-0.5 hover:bg-primary/15"
-                  title={t('composer.capabilities.removeRunCapability')}
-                  aria-label={t('composer.capabilities.removeRunCapability')}
-                >
-                  <X size={11} />
-                </button>
-              </span>
-            ))}
-          </div>
-        )}
+        <DetachedRunRuntimeCapabilities
+          options={detachedRunRuntimeCapabilityOptions}
+          runOnlyLabel={t('composer.capabilities.runOnly')}
+          removeLabel={t('composer.capabilities.removeRunCapability')}
+          onRemove={removeRunRuntimeCapability}
+        />
 
         {showGoalStatus && (
           <div
@@ -3680,20 +3265,7 @@ export function Chat({
                     {part.text}
                   </React.Fragment>
                 ) : (
-                  <span
-                    key={part.key}
-                    data-composer-capability-key={part.key}
-                    data-capability-type={part.capability.type}
-                    data-capability-id={part.capability.id}
-                    contentEditable={false}
-                    className="mx-0.5 inline-flex max-w-[14rem] select-none items-center gap-1 text-sm font-semibold text-primary align-baseline"
-                  >
-                    <RuntimeCapabilityIcon
-                      option={part.capability}
-                      variant="chip"
-                    />
-                    <span className="truncate">{part.capability.label}</span>
-                  </span>
+                  <ComposerCapabilityToken key={part.key} part={part} />
                 ),
               )}
             </div>

--- a/packages/chatkit-ui/src/components/chat/runtime-capabilities.tsx
+++ b/packages/chatkit-ui/src/components/chat/runtime-capabilities.tsx
@@ -1,0 +1,848 @@
+import * as React from 'react';
+import { X } from 'lucide-react';
+import type { Client } from '@xpert-ai/xpert-sdk';
+import { createMessageId } from '../../lib/utils';
+import { isRuntimeCapabilitiesSelection } from '../../lib/message-metadata';
+import {
+  createEmptyRuntimeCapabilitiesSelection,
+  createDefaultRuntimeCapabilitiesSelection,
+  createRuntimeCapabilitiesForSubmit,
+  getRecommendedRuntimeCapabilitiesSelection,
+  getRuntimeCapabilityOptions,
+  isRuntimeCapabilitySelected,
+  mergeRuntimeCapabilitiesSelections,
+  toggleRuntimeCapabilitySelection,
+  type RuntimeCapabilitiesSelection,
+  type RuntimeCapabilityOption,
+} from '../../lib/runtime-capabilities';
+import {
+  hasMissingRuntimeCapabilityReferences,
+  loadConversationRuntimeCapabilities,
+  persistConversationRuntimeCapabilities as persistRuntimeCapabilitiesToConversation,
+  type MissingRuntimeCapabilityReferences,
+} from '../../lib/conversation-runtime-capabilities';
+import {
+  createComposerCapabilityPart,
+  getComposerCapabilityKeys,
+  getComposerCapabilitySelectionKeys,
+  getComposerEditingLength,
+  getComposerEditingText,
+  getComposerSelectionOffset,
+  getRuntimeCapabilityOptionKey,
+  removeComposerCapabilityTokens,
+  replaceComposerRange,
+  type ComposerCapabilityPart,
+  type ComposerPart,
+} from '../../lib/composer-parts';
+import {
+  resolveRuntimeCapabilityPalette,
+  type RuntimeCapabilitiesWithCommands,
+  type RuntimeCapabilityPaletteState,
+} from '../../lib/slash-commands';
+import { RuntimeCapabilityIcon } from '../runtime-capability-icon';
+
+export type RuntimeCapabilitiesForSubmit = {
+  runtimeCapabilitiesForSubmit: RuntimeCapabilitiesSelection | null;
+  runtimeCapabilityOptionsForMessage: RuntimeCapabilityOption[];
+};
+
+type CommitComposerParts = (
+  nextParts: ComposerPart[],
+  options?: {
+    caretOffset?: number | null;
+    resetDom?: boolean;
+    syncRemovedCapabilityTokens?: boolean;
+  },
+) => void;
+
+type RuntimeCapabilitiesStateParams = {
+  client: Client<unknown> | null | undefined;
+  assistantId: string | null | undefined;
+  threadId: string | null | undefined;
+  disabled: boolean;
+  composerParts: ComposerPart[];
+};
+
+type RuntimeCapabilitiesComposerActionsParams = {
+  runtimeCapabilities: RuntimeCapabilitiesWithCommands | null;
+  runtimeCapabilitiesReady: boolean;
+  runtimeCapabilityOptions: RuntimeCapabilityOption[];
+  setRunRuntimeCapabilities: React.Dispatch<
+    React.SetStateAction<RuntimeCapabilitiesSelection>
+  >;
+  setRuntimeCapabilityPalette: React.Dispatch<
+    React.SetStateAction<RuntimeCapabilityPaletteState | null>
+  >;
+  applyExternalRuntimeCapabilities: (
+    selection: RuntimeCapabilitiesSelection | null,
+  ) => void;
+  composerInputRef: React.RefObject<HTMLDivElement | null>;
+  composerPartsRef: React.MutableRefObject<ComposerPart[]>;
+  commitComposerParts: CommitComposerParts;
+  focusComposerAt: (position?: number) => void;
+};
+
+function getHttpStatus(error: unknown): number | null {
+  if (!error || typeof error !== 'object' || !('status' in error)) {
+    return null;
+  }
+
+  const status = (error as { status?: unknown }).status;
+  return typeof status === 'number' ? status : null;
+}
+
+function warnMissingRuntimeCapabilityReferences(
+  action: string,
+  missing: MissingRuntimeCapabilityReferences,
+) {
+  if (!hasMissingRuntimeCapabilityReferences(missing)) {
+    return;
+  }
+
+  console.warn(
+    `[Chat] Runtime capabilities ${action} include unavailable references:`,
+    missing,
+  );
+}
+
+export function getRuntimeCapabilityPaletteEmptyLabelKey(
+  palette: RuntimeCapabilityPaletteState,
+  runtimeCapabilitiesReady: boolean,
+): string {
+  if (!palette.capabilityTypes || palette.capabilityTypes.length !== 1) {
+    return 'composer.capabilities.emptySearch';
+  }
+
+  if (!runtimeCapabilitiesReady) {
+    return 'composer.slashCommands.empty.loadingCapabilities';
+  }
+
+  const hasQuery = palette.query.trim().length > 0;
+  const capabilityType = palette.capabilityTypes[0];
+  if (capabilityType === 'skill') {
+    return hasQuery
+      ? 'composer.slashCommands.empty.matchingSkills'
+      : 'composer.slashCommands.empty.skills';
+  }
+
+  if (capabilityType === 'plugin') {
+    return hasQuery
+      ? 'composer.slashCommands.empty.matchingPlugins'
+      : 'composer.slashCommands.empty.plugins';
+  }
+
+  return hasQuery
+    ? 'composer.slashCommands.empty.matchingSubAgents'
+    : 'composer.slashCommands.empty.subAgents';
+}
+
+export function getRuntimeCapabilityOptionsForSelection(
+  selection: RuntimeCapabilitiesSelection | null | undefined,
+  options: RuntimeCapabilityOption[],
+): RuntimeCapabilityOption[] {
+  if (!selection) {
+    return [];
+  }
+
+  return options.filter((option) =>
+    isRuntimeCapabilitySelected(selection, option.type, option.id),
+  );
+}
+
+export function removeComposerCapabilityPartsFromSelection(
+  selection: RuntimeCapabilitiesSelection,
+  removedCapabilities: ComposerCapabilityPart[],
+): RuntimeCapabilitiesSelection {
+  let nextSelection = selection;
+  for (const part of removedCapabilities) {
+    nextSelection = toggleRuntimeCapabilitySelection(
+      nextSelection,
+      part.capability.type,
+      part.capability.id,
+      false,
+    );
+  }
+  return nextSelection;
+}
+
+export function getRemovedComposerCapabilityParts(
+  previousParts: ComposerPart[],
+  nextParts: ComposerPart[],
+): ComposerCapabilityPart[] {
+  const nextKeys = getComposerCapabilityKeys(nextParts);
+  return previousParts.filter(
+    (part): part is ComposerCapabilityPart =>
+      part.type === 'capability' && !nextKeys.has(part.key),
+  );
+}
+
+export function useRuntimeCapabilitiesState({
+  client,
+  assistantId,
+  threadId,
+  disabled,
+  composerParts,
+}: RuntimeCapabilitiesStateParams) {
+  const [runtimeCapabilities, setRuntimeCapabilities] =
+    React.useState<RuntimeCapabilitiesWithCommands | null>(null);
+  const [runtimeCapabilitiesReady, setRuntimeCapabilitiesReady] =
+    React.useState(false);
+  const [sessionRuntimeCapabilities, setSessionRuntimeCapabilities] =
+    React.useState<RuntimeCapabilitiesSelection>(() =>
+      createEmptyRuntimeCapabilitiesSelection(),
+    );
+  const [runRuntimeCapabilities, setRunRuntimeCapabilities] =
+    React.useState<RuntimeCapabilitiesSelection>(() =>
+      createEmptyRuntimeCapabilitiesSelection(),
+    );
+  const [runtimeCapabilityPalette, setRuntimeCapabilityPalette] =
+    React.useState<RuntimeCapabilityPaletteState | null>(null);
+  const runtimeCapabilityPreferenceLoadRef = React.useRef(0);
+  const pendingExternalRuntimeCapabilitiesRef =
+    React.useRef<RuntimeCapabilitiesSelection | null>(null);
+
+  const runtimeCapabilityOptions = React.useMemo(
+    () => getRuntimeCapabilityOptions(runtimeCapabilities),
+    [runtimeCapabilities],
+  );
+
+  const effectiveSessionRuntimeCapabilities = React.useMemo(
+    () =>
+      runtimeCapabilitiesReady && runtimeCapabilities
+        ? mergeRuntimeCapabilitiesSelections(
+            runtimeCapabilities,
+            sessionRuntimeCapabilities,
+          )
+        : null,
+    [runtimeCapabilities, runtimeCapabilitiesReady, sessionRuntimeCapabilities],
+  );
+
+  const runRuntimeCapabilityOptions = React.useMemo(
+    () =>
+      runtimeCapabilityOptions.filter((option) =>
+        isRuntimeCapabilitySelected(
+          runRuntimeCapabilities,
+          option.type,
+          option.id,
+        ),
+      ),
+    [runRuntimeCapabilities, runtimeCapabilityOptions],
+  );
+
+  const composerRuntimeCapabilitySelectionKeys = React.useMemo(
+    () => getComposerCapabilitySelectionKeys(composerParts),
+    [composerParts],
+  );
+
+  const detachedRunRuntimeCapabilityOptions = React.useMemo(
+    () =>
+      runRuntimeCapabilityOptions.filter(
+        (option) =>
+          !composerRuntimeCapabilitySelectionKeys.has(
+            getRuntimeCapabilityOptionKey(option),
+          ),
+      ),
+    [composerRuntimeCapabilitySelectionKeys, runRuntimeCapabilityOptions],
+  );
+
+  const persistSessionRuntimeCapabilities = React.useCallback(
+    async (
+      nextThreadId: string,
+      selection: RuntimeCapabilitiesSelection | null | undefined,
+    ) => {
+      if (!runtimeCapabilities || !selection || !client) {
+        return;
+      }
+
+      try {
+        const result = await persistRuntimeCapabilitiesToConversation({
+          client,
+          threadId: nextThreadId,
+          capabilities: runtimeCapabilities,
+          selection,
+        });
+        warnMissingRuntimeCapabilityReferences(
+          'persisted selection',
+          result.missing,
+        );
+      } catch (error) {
+        console.warn(
+          '[Chat] Failed to persist runtime capabilities selection:',
+          error,
+        );
+      }
+    },
+    [client, runtimeCapabilities],
+  );
+
+  const applyExternalRuntimeCapabilities = React.useCallback(
+    (selection: RuntimeCapabilitiesSelection | null) => {
+      pendingExternalRuntimeCapabilitiesRef.current = selection;
+      setRunRuntimeCapabilities(() => {
+        const emptySelection =
+          createEmptyRuntimeCapabilitiesSelection(runtimeCapabilities);
+        if (!selection) {
+          return emptySelection;
+        }
+        if (!runtimeCapabilities) {
+          return selection;
+        }
+
+        pendingExternalRuntimeCapabilitiesRef.current = null;
+        return mergeRuntimeCapabilitiesSelections(
+          runtimeCapabilities,
+          emptySelection,
+          selection,
+        );
+      });
+    },
+    [runtimeCapabilities],
+  );
+
+  const handleSessionRuntimeCapabilityToggle = React.useCallback(
+    (type: RuntimeCapabilityOption['type'], id: string, selected: boolean) => {
+      setSessionRuntimeCapabilities((previous) => {
+        const nextSelection = toggleRuntimeCapabilitySelection(
+          previous,
+          type,
+          id,
+          selected,
+        );
+
+        const normalizedThreadId = threadId?.trim();
+        if (normalizedThreadId) {
+          void persistSessionRuntimeCapabilities(
+            normalizedThreadId,
+            nextSelection,
+          );
+        }
+
+        return nextSelection;
+      });
+    },
+    [persistSessionRuntimeCapabilities, threadId],
+  );
+
+  const addRunRuntimeCapabilities = React.useCallback(
+    (selection: RuntimeCapabilitiesSelection) => {
+      setRunRuntimeCapabilities((previous) =>
+        runtimeCapabilities
+          ? mergeRuntimeCapabilitiesSelections(
+              runtimeCapabilities,
+              previous,
+              selection,
+            )
+          : previous,
+      );
+    },
+    [runtimeCapabilities],
+  );
+
+  const resetRunRuntimeCapabilities = React.useCallback(() => {
+    setRunRuntimeCapabilities(
+      createEmptyRuntimeCapabilitiesSelection(runtimeCapabilities),
+    );
+    setRuntimeCapabilityPalette(null);
+  }, [runtimeCapabilities]);
+
+  const getRuntimeCapabilitiesForSubmit = React.useCallback(
+    (
+      recommended?: RuntimeCapabilitiesSelection | null,
+    ): RuntimeCapabilitiesForSubmit => {
+      const recommendedRuntimeCapabilitiesForSubmit =
+        recommended && runtimeCapabilities && runtimeCapabilitiesReady
+          ? mergeRuntimeCapabilitiesSelections(
+              runtimeCapabilities,
+              runRuntimeCapabilities,
+              recommended,
+            )
+          : runRuntimeCapabilities;
+      const runtimeCapabilitiesForSubmit =
+        runtimeCapabilities && runtimeCapabilitiesReady
+          ? createRuntimeCapabilitiesForSubmit({
+              capabilities: runtimeCapabilities,
+              available: effectiveSessionRuntimeCapabilities,
+              recommended: recommendedRuntimeCapabilitiesForSubmit,
+            })
+          : null;
+      const runtimeCapabilityOptionsForMessage =
+        getRuntimeCapabilityOptionsForSelection(
+          getRecommendedRuntimeCapabilitiesSelection(
+            runtimeCapabilitiesForSubmit,
+          ),
+          runtimeCapabilityOptions,
+        );
+
+      return {
+        runtimeCapabilitiesForSubmit,
+        runtimeCapabilityOptionsForMessage,
+      };
+    },
+    [
+      effectiveSessionRuntimeCapabilities,
+      runRuntimeCapabilities,
+      runtimeCapabilities,
+      runtimeCapabilitiesReady,
+      runtimeCapabilityOptions,
+    ],
+  );
+
+  const getRuntimeCapabilitiesForCommand = React.useCallback(
+    (recommended?: RuntimeCapabilitiesSelection | null) =>
+      runtimeCapabilities && runtimeCapabilitiesReady
+        ? createRuntimeCapabilitiesForSubmit({
+            capabilities: runtimeCapabilities,
+            available: effectiveSessionRuntimeCapabilities,
+            recommended,
+          })
+        : (recommended ?? null),
+    [
+      effectiveSessionRuntimeCapabilities,
+      runtimeCapabilities,
+      runtimeCapabilitiesReady,
+    ],
+  );
+
+  React.useEffect(() => {
+    if (disabled || !client || !assistantId) {
+      pendingExternalRuntimeCapabilitiesRef.current = null;
+      setRuntimeCapabilities(null);
+      setRuntimeCapabilitiesReady(false);
+      setSessionRuntimeCapabilities(createEmptyRuntimeCapabilitiesSelection());
+      setRunRuntimeCapabilities(createEmptyRuntimeCapabilitiesSelection());
+      setRuntimeCapabilityPalette(null);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    setRuntimeCapabilitiesReady(false);
+    setRuntimeCapabilities(null);
+    setRuntimeCapabilityPalette(null);
+
+    void client.assistants
+      .getRuntimeCapabilities(assistantId, {
+        signal: controller.signal,
+      })
+      .then((payload) => {
+        setRuntimeCapabilities(payload);
+        setRuntimeCapabilitiesReady(true);
+        setSessionRuntimeCapabilities(
+          createDefaultRuntimeCapabilitiesSelection(payload),
+        );
+        setRunRuntimeCapabilities(
+          createEmptyRuntimeCapabilitiesSelection(payload),
+        );
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        if (getHttpStatus(error) === 404) {
+          setRuntimeCapabilities(null);
+          setRuntimeCapabilitiesReady(false);
+          setSessionRuntimeCapabilities(
+            createEmptyRuntimeCapabilitiesSelection(),
+          );
+          setRunRuntimeCapabilities(createEmptyRuntimeCapabilitiesSelection());
+          return;
+        }
+        console.warn('[Chat] Failed to load runtime capabilities:', error);
+        setRuntimeCapabilities(null);
+        setRuntimeCapabilitiesReady(false);
+        setSessionRuntimeCapabilities(
+          createEmptyRuntimeCapabilitiesSelection(),
+        );
+        setRunRuntimeCapabilities(createEmptyRuntimeCapabilitiesSelection());
+      });
+
+    return () => controller.abort();
+  }, [assistantId, client, disabled]);
+
+  React.useEffect(() => {
+    const emptyRunSelection =
+      createEmptyRuntimeCapabilitiesSelection(runtimeCapabilities);
+    const pendingExternalSelection =
+      pendingExternalRuntimeCapabilitiesRef.current;
+
+    if (pendingExternalSelection && runtimeCapabilities) {
+      setRunRuntimeCapabilities(
+        mergeRuntimeCapabilitiesSelections(
+          runtimeCapabilities,
+          emptyRunSelection,
+          pendingExternalSelection,
+        ),
+      );
+      pendingExternalRuntimeCapabilitiesRef.current = null;
+    } else {
+      setRunRuntimeCapabilities(pendingExternalSelection ?? emptyRunSelection);
+    }
+
+    if (!runtimeCapabilitiesReady || !runtimeCapabilities || !client) {
+      setSessionRuntimeCapabilities(
+        createEmptyRuntimeCapabilitiesSelection(runtimeCapabilities),
+      );
+      return;
+    }
+
+    const defaultSelection =
+      createDefaultRuntimeCapabilitiesSelection(runtimeCapabilities);
+    const normalizedThreadId = threadId?.trim();
+    if (!normalizedThreadId) {
+      setSessionRuntimeCapabilities(defaultSelection);
+      return;
+    }
+
+    let cancelled = false;
+    const requestId = runtimeCapabilityPreferenceLoadRef.current + 1;
+    runtimeCapabilityPreferenceLoadRef.current = requestId;
+    setSessionRuntimeCapabilities(defaultSelection);
+
+    void loadConversationRuntimeCapabilities({
+      client,
+      threadId: normalizedThreadId,
+      capabilities: runtimeCapabilities,
+    })
+      .then(({ selection, missing }) => {
+        if (
+          cancelled ||
+          runtimeCapabilityPreferenceLoadRef.current !== requestId
+        ) {
+          return;
+        }
+
+        warnMissingRuntimeCapabilityReferences('loaded selection', missing);
+        setSessionRuntimeCapabilities(selection ?? defaultSelection);
+      })
+      .catch((error: unknown) => {
+        if (
+          cancelled ||
+          runtimeCapabilityPreferenceLoadRef.current !== requestId
+        ) {
+          return;
+        }
+        console.warn(
+          '[Chat] Failed to load persisted runtime capabilities selection:',
+          error,
+        );
+        setSessionRuntimeCapabilities(defaultSelection);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    client,
+    runtimeCapabilities,
+    runtimeCapabilitiesReady,
+    threadId,
+  ]);
+
+  return {
+    runtimeCapabilities,
+    runtimeCapabilitiesReady,
+    runtimeCapabilityOptions,
+    effectiveSessionRuntimeCapabilities,
+    runRuntimeCapabilities,
+    runRuntimeCapabilityOptions,
+    detachedRunRuntimeCapabilityOptions,
+    runtimeCapabilityPalette,
+    setRunRuntimeCapabilities,
+    setRuntimeCapabilityPalette,
+    applyExternalRuntimeCapabilities,
+    handleSessionRuntimeCapabilityToggle,
+    addRunRuntimeCapabilities,
+    resetRunRuntimeCapabilities,
+    getRuntimeCapabilitiesForSubmit,
+    getRuntimeCapabilitiesForCommand,
+    persistSessionRuntimeCapabilities,
+  };
+}
+
+export function useRuntimeCapabilityComposerActions({
+  runtimeCapabilities,
+  runtimeCapabilitiesReady,
+  runtimeCapabilityOptions,
+  setRunRuntimeCapabilities,
+  setRuntimeCapabilityPalette,
+  applyExternalRuntimeCapabilities,
+  composerInputRef,
+  composerPartsRef,
+  commitComposerParts,
+  focusComposerAt,
+}: RuntimeCapabilitiesComposerActionsParams) {
+  const pendingExternalRuntimeCapabilityInsertRef =
+    React.useRef<RuntimeCapabilitiesSelection | null>(null);
+
+  const insertExternalRuntimeCapabilities = React.useCallback(
+    (selection: RuntimeCapabilitiesSelection | null) => {
+      applyExternalRuntimeCapabilities(selection);
+      if (!selection) {
+        pendingExternalRuntimeCapabilityInsertRef.current = null;
+        return;
+      }
+
+      if (!runtimeCapabilitiesReady || !runtimeCapabilities) {
+        pendingExternalRuntimeCapabilityInsertRef.current = selection;
+        return;
+      }
+
+      pendingExternalRuntimeCapabilityInsertRef.current = null;
+      const existingKeys = getComposerCapabilitySelectionKeys(
+        composerPartsRef.current,
+      );
+      const selectedOptions = runtimeCapabilityOptions.filter(
+        (option) =>
+          isRuntimeCapabilitySelected(selection, option.type, option.id) &&
+          !existingKeys.has(getRuntimeCapabilityOptionKey(option)),
+      );
+
+      if (selectedOptions.length === 0) {
+        focusComposerAt();
+        return;
+      }
+
+      const currentParts = composerPartsRef.current;
+      const insertAt = getComposerEditingLength(currentParts);
+      const nextParts = replaceComposerRange(
+        currentParts,
+        insertAt,
+        insertAt,
+        selectedOptions.map((option) =>
+          createComposerCapabilityPart(option, createMessageId()),
+        ),
+      );
+      const nextCaretOffset = insertAt + selectedOptions.length;
+      commitComposerParts(nextParts, {
+        caretOffset: nextCaretOffset,
+        resetDom: true,
+        syncRemovedCapabilityTokens: true,
+      });
+      setRuntimeCapabilityPalette(null);
+      focusComposerAt(nextCaretOffset);
+    },
+    [
+      applyExternalRuntimeCapabilities,
+      commitComposerParts,
+      composerPartsRef,
+      focusComposerAt,
+      runtimeCapabilities,
+      runtimeCapabilitiesReady,
+      runtimeCapabilityOptions,
+      setRuntimeCapabilityPalette,
+    ],
+  );
+
+  const applyComposerValueRuntimeCapabilities = React.useCallback(
+    (payload: {
+      runtimeCapabilities?: RuntimeCapabilitiesSelection | null;
+      insertRuntimeCapabilities?: boolean;
+    }) => {
+      const runtimeCapabilitiesPayload =
+        isRuntimeCapabilitiesSelection(payload.runtimeCapabilities)
+          ? payload.runtimeCapabilities
+          : payload.runtimeCapabilities === null
+            ? null
+            : undefined;
+      if (runtimeCapabilitiesPayload === undefined) {
+        return;
+      }
+
+      if (payload.insertRuntimeCapabilities === true) {
+        insertExternalRuntimeCapabilities(runtimeCapabilitiesPayload);
+      } else {
+        applyExternalRuntimeCapabilities(runtimeCapabilitiesPayload);
+      }
+    },
+    [applyExternalRuntimeCapabilities, insertExternalRuntimeCapabilities],
+  );
+
+  const updateRuntimeCapabilityPalette = React.useCallback(
+    (parts: ComposerPart[], selectionStart?: number | null) => {
+      const input = composerInputRef.current;
+      const editingText = getComposerEditingText(parts);
+      const nextPalette = resolveRuntimeCapabilityPalette(
+        editingText,
+        typeof selectionStart === 'number'
+          ? selectionStart
+          : input
+            ? getComposerSelectionOffset(input)
+            : getComposerEditingLength(parts),
+      );
+      setRuntimeCapabilityPalette(nextPalette);
+    },
+    [composerInputRef, setRuntimeCapabilityPalette],
+  );
+
+  const removeRunRuntimeCapability = React.useCallback(
+    (option: RuntimeCapabilityOption) => {
+      setRunRuntimeCapabilities((previous) =>
+        toggleRuntimeCapabilitySelection(
+          previous,
+          option.type,
+          option.id,
+          false,
+        ),
+      );
+      commitComposerParts(
+        removeComposerCapabilityTokens(composerPartsRef.current, option),
+        {
+          resetDom: true,
+          syncRemovedCapabilityTokens: false,
+        },
+      );
+    },
+    [commitComposerParts, composerPartsRef, setRunRuntimeCapabilities],
+  );
+
+  const insertComposerCapabilityToken = React.useCallback(
+    (
+      capability: RuntimeCapabilityOption,
+      range?: { start: number; end: number },
+    ) => {
+      const token = createComposerCapabilityPart(capability, createMessageId());
+      const currentParts = composerPartsRef.current;
+      const replaceRange = range ?? {
+        start: getComposerEditingLength(currentParts),
+        end: getComposerEditingLength(currentParts),
+      };
+      const nextParts = replaceComposerRange(
+        currentParts,
+        replaceRange.start,
+        replaceRange.end,
+        [token],
+      );
+      commitComposerParts(nextParts, {
+        caretOffset: replaceRange.start + 1,
+        resetDom: true,
+        syncRemovedCapabilityTokens: true,
+      });
+      setRunRuntimeCapabilities((previous) =>
+        toggleRuntimeCapabilitySelection(
+          previous,
+          capability.type,
+          capability.id,
+          true,
+        ),
+      );
+      setRuntimeCapabilityPalette(null);
+      focusComposerAt(replaceRange.start + 1);
+    },
+    [
+      commitComposerParts,
+      composerPartsRef,
+      focusComposerAt,
+      setRunRuntimeCapabilities,
+      setRuntimeCapabilityPalette,
+    ],
+  );
+
+  React.useEffect(() => {
+    if (!runtimeCapabilitiesReady || !runtimeCapabilities) {
+      return;
+    }
+
+    const pendingSelection = pendingExternalRuntimeCapabilityInsertRef.current;
+    if (!pendingSelection) {
+      return;
+    }
+
+    insertExternalRuntimeCapabilities(pendingSelection);
+  }, [
+    insertExternalRuntimeCapabilities,
+    runtimeCapabilities,
+    runtimeCapabilitiesReady,
+  ]);
+
+  return {
+    applyComposerValueRuntimeCapabilities,
+    insertExternalRuntimeCapabilities,
+    updateRuntimeCapabilityPalette,
+    removeRunRuntimeCapability,
+    insertComposerCapabilityToken,
+  };
+}
+
+export function HumanRuntimeCapabilityChips({
+  options,
+}: {
+  options: RuntimeCapabilityOption[];
+}) {
+  if (options.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-2 flex flex-wrap gap-1.5">
+      {options.map((option) => (
+        <span
+          key={`${option.type}:${option.id}`}
+          className="inline-flex max-w-full items-center gap-1 rounded-md bg-primary-foreground/20 px-2 py-1 text-xs font-medium text-primary-foreground"
+        >
+          <RuntimeCapabilityIcon option={option} variant="chip" />
+          <span className="max-w-[9rem] truncate">{option.label}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function DetachedRunRuntimeCapabilities({
+  options,
+  runOnlyLabel,
+  removeLabel,
+  onRemove,
+}: {
+  options: RuntimeCapabilityOption[];
+  runOnlyLabel: string;
+  removeLabel: string;
+  onRemove: (option: RuntimeCapabilityOption) => void;
+}) {
+  if (options.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-2 flex flex-wrap items-center gap-2">
+      <span className="text-xs text-muted-foreground">{runOnlyLabel}</span>
+      {options.map((option) => (
+        <span
+          key={`${option.type}:${option.id}`}
+          className="inline-flex max-w-full items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+        >
+          <RuntimeCapabilityIcon option={option} variant="chip" />
+          <span className="max-w-40 truncate">{option.label}</span>
+          <button
+            type="button"
+            onClick={() => onRemove(option)}
+            className="rounded-full p-0.5 hover:bg-primary/15"
+            title={removeLabel}
+            aria-label={removeLabel}
+          >
+            <X size={11} />
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function ComposerCapabilityToken({
+  part,
+}: {
+  part: ComposerCapabilityPart;
+}) {
+  return (
+    <span
+      key={part.key}
+      data-composer-capability-key={part.key}
+      data-capability-type={part.capability.type}
+      data-capability-id={part.capability.id}
+      contentEditable={false}
+      className="mx-0.5 inline-flex max-w-[14rem] select-none items-center gap-1 text-sm font-semibold text-primary align-baseline"
+    >
+      <RuntimeCapabilityIcon option={part.capability} variant="chip" />
+      <span className="truncate">{part.capability.label}</span>
+    </span>
+  );
+}

--- a/packages/chatkit-ui/src/hooks/useParentMessenger.tsx
+++ b/packages/chatkit-ui/src/hooks/useParentMessenger.tsx
@@ -5,6 +5,7 @@ import {
   type ParentMessenger,
 } from '../providers/ParentMessenger';
 import type { ComposerValuePayload } from '../lib/references';
+import type { RuntimeCapabilitiesSelection } from '../lib/runtime-capabilities';
 
 export type { ParentMessenger } from '../providers/ParentMessenger';
 
@@ -12,6 +13,9 @@ export type ParentMessengerOptions = {
   onSetOptions?: (options: ChatKitOptions | null) => void;
   onSetPetEnabled?: (enabled: boolean) => void;
   onSetComposerValue?: (payload: ComposerValuePayload | null) => void;
+  onSetRuntimeCapabilities?: (
+    selection: RuntimeCapabilitiesSelection | null,
+  ) => void;
   onFocusComposer?: () => void;
 };
 
@@ -19,6 +23,7 @@ export function useParentMessenger({
   onSetOptions,
   onSetPetEnabled,
   onSetComposerValue,
+  onSetRuntimeCapabilities,
   onFocusComposer,
 }: ParentMessengerOptions = {}): ParentMessenger {
   const context = useContext(ParentMessengerContext);
@@ -32,12 +37,14 @@ export function useParentMessenger({
     registerOnSetOptions,
     registerOnSetPetEnabled,
     registerOnSetComposerValue,
+    registerOnSetRuntimeCapabilities,
     registerOnFocusComposer,
     ...messenger
   } = context;
   const onSetOptionsRef = useRef(onSetOptions);
   const onSetPetEnabledRef = useRef(onSetPetEnabled);
   const onSetComposerValueRef = useRef(onSetComposerValue);
+  const onSetRuntimeCapabilitiesRef = useRef(onSetRuntimeCapabilities);
   const onFocusComposerRef = useRef(onFocusComposer);
   useEffect(() => {
     onSetOptionsRef.current = onSetOptions;
@@ -49,12 +56,16 @@ export function useParentMessenger({
     onSetComposerValueRef.current = onSetComposerValue;
   }, [onSetComposerValue]);
   useEffect(() => {
+    onSetRuntimeCapabilitiesRef.current = onSetRuntimeCapabilities;
+  }, [onSetRuntimeCapabilities]);
+  useEffect(() => {
     onFocusComposerRef.current = onFocusComposer;
   }, [onFocusComposer]);
 
   const hasOnSetOptions = Boolean(onSetOptions);
   const hasOnSetPetEnabled = Boolean(onSetPetEnabled);
   const hasOnSetComposerValue = Boolean(onSetComposerValue);
+  const hasOnSetRuntimeCapabilities = Boolean(onSetRuntimeCapabilities);
   const hasOnFocusComposer = Boolean(onFocusComposer);
   useEffect(() => {
     if (!hasOnSetOptions) return;
@@ -79,6 +90,14 @@ export function useParentMessenger({
     };
     return registerOnSetComposerValue(handler);
   }, [hasOnSetComposerValue, registerOnSetComposerValue]);
+
+  useEffect(() => {
+    if (!hasOnSetRuntimeCapabilities) return;
+    const handler = (selection: RuntimeCapabilitiesSelection | null) => {
+      onSetRuntimeCapabilitiesRef.current?.(selection);
+    };
+    return registerOnSetRuntimeCapabilities(handler);
+  }, [hasOnSetRuntimeCapabilities, registerOnSetRuntimeCapabilities]);
 
   useEffect(() => {
     if (!hasOnFocusComposer) return;

--- a/packages/chatkit-ui/src/lib/references.ts
+++ b/packages/chatkit-ui/src/lib/references.ts
@@ -6,6 +6,7 @@ import type {
   ChatKitReference,
   ChatKitReferenceCompositionMode,
 } from '@xpert-ai/chatkit-types';
+import type { RuntimeCapabilitiesSelection } from './runtime-capabilities';
 
 export type ComposerValuePayload = {
   text?: string;
@@ -15,6 +16,8 @@ export type ComposerValuePayload = {
   appendReferences?: boolean;
   selectedToolId?: string | null;
   selectedModelId?: string | null;
+  runtimeCapabilities?: RuntimeCapabilitiesSelection | null;
+  insertRuntimeCapabilities?: boolean;
 };
 
 type ReferenceCandidate = {

--- a/packages/chatkit-ui/src/providers/ParentMessenger.test.tsx
+++ b/packages/chatkit-ui/src/providers/ParentMessenger.test.tsx
@@ -29,6 +29,24 @@ function PetEnabledProbe({
   return null;
 }
 
+function RuntimeCapabilitiesProbe({
+  onSetRuntimeCapabilities,
+}: {
+  onSetRuntimeCapabilities?: (selection: unknown) => void;
+}) {
+  useParentMessenger({ onSetRuntimeCapabilities });
+  return null;
+}
+
+function ComposerValueProbe({
+  onSetComposerValue,
+}: {
+  onSetComposerValue: (payload: unknown) => void;
+}) {
+  useParentMessenger({ onSetComposerValue });
+  return null;
+}
+
 function ChatMinimizeEventProbe() {
   const parentMessenger = useParentMessenger();
 
@@ -227,6 +245,108 @@ describe('ParentMessengerProvider', () => {
         __xpaiChatKit: true,
         type: 'response',
         nonce: 'pet-enabled-test',
+        response: { ok: true },
+      }),
+      '*',
+    );
+  });
+
+  it('dispatches setRuntimeCapabilities commands to registered handlers', async () => {
+    const onSetRuntimeCapabilities = vi.fn();
+    const runtimeCapabilities = {
+      mode: 'allowlist' as const,
+      skills: { workspaceId: 'workspace-1', ids: ['skill-1'] },
+      plugins: { nodeKeys: [] },
+      subAgents: { nodeKeys: [] },
+    };
+
+    render(
+      <ParentMessengerProvider>
+        <RuntimeCapabilitiesProbe
+          onSetRuntimeCapabilities={onSetRuntimeCapabilities}
+        />
+      </ParentMessengerProvider>,
+    );
+
+    const event = new MessageEvent('message', {
+      data: {
+        __xpaiChatKit: true,
+        type: 'command',
+        command: 'onSetRuntimeCapabilities',
+        nonce: 'runtime-capabilities-command-test',
+        data: runtimeCapabilities,
+      },
+      origin: 'https://example.com',
+    });
+    Object.defineProperty(event, 'source', {
+      configurable: true,
+      value: parentWindow,
+    });
+
+    window.dispatchEvent(event);
+
+    await waitFor(() =>
+      expect(onSetRuntimeCapabilities).toHaveBeenCalledWith(
+        runtimeCapabilities,
+      ),
+    );
+    expect(parentWindow.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        __xpaiChatKit: true,
+        type: 'response',
+        nonce: 'runtime-capabilities-command-test',
+        response: { ok: true },
+      }),
+      '*',
+    );
+  });
+
+  it('dispatches setComposerValue runtime capability insert payloads to registered handlers', async () => {
+    const onSetComposerValue = vi.fn();
+    const runtimeCapabilities = {
+      mode: 'allowlist' as const,
+      skills: { workspaceId: 'workspace-1', ids: ['skill-1'] },
+      plugins: { nodeKeys: [] },
+      subAgents: { nodeKeys: [] },
+    };
+
+    render(
+      <ParentMessengerProvider>
+        <ComposerValueProbe onSetComposerValue={onSetComposerValue} />
+      </ParentMessengerProvider>,
+    );
+
+    const event = new MessageEvent('message', {
+      data: {
+        __xpaiChatKit: true,
+        type: 'command',
+        command: 'onSetComposerValue',
+        nonce: 'runtime-capabilities-insert-command-test',
+        data: {
+          runtimeCapabilities,
+          insertRuntimeCapabilities: true,
+        },
+      },
+      origin: 'https://example.com',
+    });
+    Object.defineProperty(event, 'source', {
+      configurable: true,
+      value: parentWindow,
+    });
+
+    window.dispatchEvent(event);
+
+    await waitFor(() =>
+      expect(onSetComposerValue).toHaveBeenCalledWith({
+        runtimeCapabilities,
+        insertRuntimeCapabilities: true,
+      }),
+    );
+    expect(parentWindow.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        __xpaiChatKit: true,
+        type: 'response',
+        nonce: 'runtime-capabilities-insert-command-test',
         response: { ok: true },
       }),
       '*',

--- a/packages/chatkit-ui/src/providers/ParentMessenger.tsx
+++ b/packages/chatkit-ui/src/providers/ParentMessenger.tsx
@@ -30,6 +30,7 @@ import { createMessageId } from '../lib/utils';
 type CommandMessageMap = {
   onSendUserMessage: SendUserMessageParams;
   onSetComposerValue: ComposerValuePayload | null;
+  onSetRuntimeCapabilities: RuntimeCapabilitiesSelection | null;
   onSetOptions: ChatKitOptions | null;
   onSetPetEnabled: { enabled: boolean };
   onFocusComposer: null;
@@ -123,6 +124,9 @@ type OnSetPetEnabledHandler = (enabled: boolean) => void;
 type OnSetComposerValueHandler = (
   payload: ComposerValuePayload | null,
 ) => void | Promise<void>;
+type OnSetRuntimeCapabilitiesHandler = (
+  selection: RuntimeCapabilitiesSelection | null,
+) => void | Promise<void>;
 type OnFocusComposerHandler = () => void | Promise<void>;
 
 type ParentMessengerContextValue = ParentMessenger & {
@@ -130,6 +134,9 @@ type ParentMessengerContextValue = ParentMessenger & {
   registerOnSetPetEnabled: (handler: OnSetPetEnabledHandler) => () => void;
   registerOnSetComposerValue: (
     handler: OnSetComposerValueHandler,
+  ) => () => void;
+  registerOnSetRuntimeCapabilities: (
+    handler: OnSetRuntimeCapabilitiesHandler,
   ) => () => void;
   registerOnFocusComposer: (handler: OnFocusComposerHandler) => () => void;
 };
@@ -156,6 +163,9 @@ export function ParentMessengerProvider({
   const onSetPetEnabledHandlersRef = useRef(new Set<OnSetPetEnabledHandler>());
   const onSetComposerValueHandlersRef = useRef(
     new Set<OnSetComposerValueHandler>(),
+  );
+  const onSetRuntimeCapabilitiesHandlersRef = useRef(
+    new Set<OnSetRuntimeCapabilitiesHandler>(),
   );
   const onFocusComposerHandlersRef = useRef(new Set<OnFocusComposerHandler>());
   const latestOptionsRef = useRef<ChatKitOptions | null>(null);
@@ -190,6 +200,16 @@ export function ParentMessengerProvider({
       onSetComposerValueHandlersRef.current.add(handler);
       return () => {
         onSetComposerValueHandlersRef.current.delete(handler);
+      };
+    },
+    [],
+  );
+
+  const registerOnSetRuntimeCapabilities = useCallback(
+    (handler: OnSetRuntimeCapabilitiesHandler) => {
+      onSetRuntimeCapabilitiesHandlersRef.current.add(handler);
+      return () => {
+        onSetRuntimeCapabilitiesHandlersRef.current.delete(handler);
       };
     },
     [],
@@ -388,6 +408,31 @@ export function ParentMessengerProvider({
         return;
       }
 
+      if (
+        payload.type === 'command' &&
+        payload.command === 'onSetRuntimeCapabilities'
+      ) {
+        const selection = isRuntimeCapabilitiesSelection(payload.data)
+          ? (payload.data as RuntimeCapabilitiesSelection)
+          : null;
+        void Promise.all(
+          [...onSetRuntimeCapabilitiesHandlersRef.current].map((handler) =>
+            Promise.resolve(handler(selection)),
+          ),
+        )
+          .then(() => {
+            if (payload.nonce) {
+              sendResponse(payload.nonce, { ok: true });
+            }
+          })
+          .catch((error) => {
+            if (payload.nonce) {
+              sendResponse(payload.nonce, undefined, error);
+            }
+          });
+        return;
+      }
+
       if (payload.type === 'command' && payload.command === 'onSetOptions') {
         latestOptionsRef.current =
           (payload.data as ChatKitOptions | null) ?? null;
@@ -534,6 +579,7 @@ export function ParentMessengerProvider({
       registerOnSetOptions,
       registerOnSetPetEnabled,
       registerOnSetComposerValue,
+      registerOnSetRuntimeCapabilities,
       registerOnFocusComposer,
     }),
     [
@@ -543,6 +589,7 @@ export function ParentMessengerProvider({
       registerOnSetOptions,
       registerOnSetPetEnabled,
       registerOnSetComposerValue,
+      registerOnSetRuntimeCapabilities,
       registerOnFocusComposer,
     ],
   );

--- a/packages/chatkit-ui5/src/chatkit.ts
+++ b/packages/chatkit-ui5/src/chatkit.ts
@@ -34,6 +34,7 @@ const CHATKIT_METHOD_NAMES = Object.freeze([
   'setThreadId',
   'sendUserMessage',
   'setComposerValue',
+  'setRuntimeCapabilities',
   'fetchUpdates',
   'sendCustomAction',
 ] as const);
@@ -284,6 +285,9 @@ export const ChatKit = ControlBase.extend('xpertai.chatkit.ui5.ChatKit', {
   },
   setComposerValue(this: ChatKitInstance, ...args: ChatKitMethodParams<'setComposerValue'>) {
     return this._callMethod('setComposerValue', ...args);
+  },
+  setRuntimeCapabilities(this: ChatKitInstance, ...args: ChatKitMethodParams<'setRuntimeCapabilities'>) {
+    return this._callMethod('setRuntimeCapabilities', ...args);
   },
   fetchUpdates(this: ChatKitInstance, ...args: ChatKitMethodParams<'fetchUpdates'>) {
     return this._callMethod('fetchUpdates', ...args);

--- a/packages/chatkit-vue/src/useChatKit.ts
+++ b/packages/chatkit-vue/src/useChatKit.ts
@@ -11,6 +11,7 @@ const CHATKIT_METHOD_NAMES = Object.freeze([
   'setThreadId',
   'sendUserMessage',
   'setComposerValue',
+  'setRuntimeCapabilities',
   'fetchUpdates',
   'sendCustomAction',
 ] as const);

--- a/packages/chatkit-vue2/src/control.ts
+++ b/packages/chatkit-vue2/src/control.ts
@@ -13,6 +13,7 @@ const CHATKIT_METHOD_NAMES = Object.freeze([
   'setThreadId',
   'sendUserMessage',
   'setComposerValue',
+  'setRuntimeCapabilities',
   'fetchUpdates',
   'sendCustomAction',
 ] as const);
@@ -141,6 +142,12 @@ class ChatKitController {
 
   setComposerValue(...args: Parameters<XpertAIChatKit['setComposerValue']>) {
     return this.callMethod('setComposerValue', ...args);
+  }
+
+  setRuntimeCapabilities(
+    ...args: Parameters<XpertAIChatKit['setRuntimeCapabilities']>
+  ) {
+    return this.callMethod('setRuntimeCapabilities', ...args);
   }
 
   fetchUpdates(...args: Parameters<XpertAIChatKit['fetchUpdates']>) {

--- a/packages/chatkit-web-shared/src/types/capabilities.types.ts
+++ b/packages/chatkit-web-shared/src/types/capabilities.types.ts
@@ -101,6 +101,8 @@ export type SetComposerValueCommandPayload = {
     files?: File[]
     selectedToolId?: string | null
     selectedModelId?: string | null
+    runtimeCapabilities?: RuntimeCapabilitiesSelection | null
+    insertRuntimeCapabilities?: boolean
 }
 
 export type CustomActionCommandPayload = {
@@ -127,6 +129,7 @@ export type OuterCommands = {
     sendUserMessage: (params: SendUserMessageCommandPayload) => void
     setPetEnabled: (params: { enabled: boolean }) => void
     setComposerValue: (params: SetComposerValueCommandPayload) => void
+    setRuntimeCapabilities: (selection: RuntimeCapabilitiesSelection | null) => void
     setThreadId: (params: { threadId: string | null }) => void
     focusComposer: () => void
     fetchUpdates: () => void
@@ -205,6 +208,7 @@ export const BASE_CAPABILITY_ALLOWLIST = [
   "command.setOptions",
   "command.sendUserMessage",
   "command.setComposerValue",
+  "command.setRuntimeCapabilities",
   "command.setThreadId",
   "command.focusComposer",
   "command.fetchUpdates",

--- a/packages/chatkit/src/chatkit.ts
+++ b/packages/chatkit/src/chatkit.ts
@@ -123,7 +123,14 @@ export interface XpertAIChatKit extends HTMLElement {
     appendReferences?: boolean;
     selectedToolId?: string | null;
     selectedModelId?: string | null;
+    runtimeCapabilities?: RuntimeCapabilitiesSelection | null;
+    insertRuntimeCapabilities?: boolean;
   }): Promise<void>;
+
+  /** Sets the selected runtime capabilities for the next user message without sending it. */
+  setRuntimeCapabilities(
+    selection: RuntimeCapabilitiesSelection | null,
+  ): Promise<void>;
 
   /**
    * Manually fetches updates from the server.

--- a/packages/web-component/src/ChatKitElementBase.ts
+++ b/packages/web-component/src/ChatKitElementBase.ts
@@ -11,6 +11,7 @@ import type {
 } from '@xpert-ai/chatkit-types';
 import { normalizePetOptions } from '@xpert-ai/chatkit-types';
 import type { ChatKitReference } from '@xpert-ai/chatkit-types';
+import type { RuntimeCapabilitiesSelection } from '@xpert-ai/chatkit-types';
 import type { SendUserMessageParams } from '@xpert-ai/chatkit-types';
 import { removeMethods } from './helpers';
 
@@ -875,9 +876,17 @@ export abstract class ChatKitElementBase<TRawOptions> extends HTMLElement {
     files?: File[];
     selectedToolId?: string | null;
     selectedModelId?: string | null;
+    runtimeCapabilities?: RuntimeCapabilitiesSelection | null;
+    insertRuntimeCapabilities?: boolean;
   }) {
     await this.#loaded;
     await this.#messenger?.commands.setComposerValue(params);
+  }
+
+  @requireCommandCapability
+  async setRuntimeCapabilities(selection: RuntimeCapabilitiesSelection | null) {
+    await this.#loaded;
+    await this.#messenger?.commands.setRuntimeCapabilities(selection);
   }
 
   @requireCommandCapability


### PR DESCRIPTION
## Summary

- Extend `setComposerValue` so hosts can pass runtime capability selections and optionally insert them into the composer as capability tokens.
- Keep runtime capability selection and insertion logic inside ChatKit UI while avoiding a new public `insertRuntimeCapabilities` method.
- Extract the RuntimeCapabilities state, persistence, composer token handling, and chip rendering from `chat.tsx` into a dedicated `runtime-capabilities.tsx` module.
- Update framework wrappers and shared command payload types to match the expanded `setComposerValue` payload.

## Why

The ClawXpert skill trial flow needs to open a fresh conversation, preselect a skill, and show the selected skill in the ChatKit composer without automatically sending a message. Reusing `setComposerValue` keeps the public API surface smaller while still supporting the new composer-token behavior.

## Validation

- `./node_modules/.bin/tsc -p packages/chatkit-ui/tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run --config vitest.config.ts src/components/chat.plan-mode.test.tsx src/providers/ParentMessenger.test.tsx`
- Wrapper/core type checks were run earlier for `chatkit`, `web-component`, Angular, React, Vue, Vue2, UI5, and `chatkit-js`.

## Notes

- This PR uses `develop` as the head branch and `main` as the base branch.
- `develop` and `main` have diverged, so please review the final GitHub diff and mergeability status before marking ready for review.