### PR TITLE
[codex] Add ChatKit skill colors and composer insertion order

### DIFF
--- a/.changeset/calm-composers-order.md
+++ b/.changeset/calm-composers-order.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/chatkit-ui': patch
+---
+
+Place inserted runtime capability composer chips before prompt text when both are provided by setComposerValue.

--- a/.changeset/kind-skill-colors.md
+++ b/.changeset/kind-skill-colors.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/chatkit-ui': patch
+---
+
+Render runtime capability chips and selectors with capability metadata colors.

--- a/packages/chatkit-ui/src/components/chat.plan-mode.test.tsx
+++ b/packages/chatkit-ui/src/components/chat.plan-mode.test.tsx
@@ -2111,6 +2111,9 @@ describe('Chat plan mode payload', () => {
             workspaceId: 'workspace-1',
             label: 'documents',
             repositoryName: 'Documents',
+            meta: {
+              color: '#2563EB',
+            },
           },
         ],
         plugins: [],
@@ -2148,11 +2151,14 @@ describe('Chat plan mode payload', () => {
     );
 
     let textbox = screen.getByRole('textbox');
-    expect(
-      textbox.querySelector('[data-composer-capability-key]'),
-    ).toHaveAttribute('data-capability-id', 'skill-docs');
+    const capabilityToken = textbox.querySelector(
+      '[data-composer-capability-key]',
+    );
+    expect(capabilityToken).toHaveAttribute('data-capability-id', 'skill-docs');
+    expect(capabilityToken).toHaveStyle({ color: '#2563EB' });
+    expect(textbox.textContent).toContain('documents ');
 
-    textbox = insertComposerText(textbox, ' create a doc');
+    textbox = insertComposerText(textbox, 'create a doc');
     const send = screen.getByRole('button', { name: 'send' });
     await waitFor(() => expect(send).not.toBeDisabled());
     fireEvent.click(send);
@@ -2171,6 +2177,58 @@ describe('Chat plan mode payload', () => {
         subAgents: { nodeKeys: [] },
       },
     });
+  });
+
+  it('places parent-requested runtime capability tokens before prompt text', async () => {
+    mocks.stream.client.assistants.getRuntimeCapabilities.mockResolvedValueOnce(
+      {
+        skills: [
+          {
+            id: 'skill-docs',
+            workspaceId: 'workspace-1',
+            label: 'documents',
+            repositoryName: 'Documents',
+          },
+        ],
+        plugins: [],
+        subAgents: [],
+      },
+    );
+
+    renderChat();
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('runtime-capabilities-ready'),
+      ).toHaveTextContent('ready'),
+    );
+
+    const prompt = 'Draft a project memo as a document';
+    await act(async () => {
+      mocks.parentMessengerOptions?.onSetComposerValue?.({
+        text: prompt,
+        runtimeCapabilities: {
+          mode: 'allowlist',
+          skills: { workspaceId: 'workspace-1', ids: ['skill-docs'] },
+          plugins: { nodeKeys: [] },
+          subAgents: { nodeKeys: [] },
+        },
+        insertRuntimeCapabilities: true,
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByRole('textbox')).getByText('documents'),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('textbox')).toHaveTextContent(prompt);
+
+    const textContent = screen.getByRole('textbox').textContent ?? '';
+    expect(textContent).toContain(`documents ${prompt}`);
+    expect(textContent.indexOf('documents')).toBeLessThan(
+      textContent.indexOf(prompt),
+    );
   });
 
   it('keeps the contenteditable node stable during IME composition', async () => {

--- a/packages/chatkit-ui/src/components/chat.tsx
+++ b/packages/chatkit-ui/src/components/chat.tsx
@@ -890,6 +890,10 @@ export function Chat({
           return;
         }
 
+        const shouldInsertRuntimeCapabilitiesBeforeText =
+          typeof payload.text === 'string' &&
+          payload.insertRuntimeCapabilities === true;
+
         if (typeof payload.text === 'string') {
           setComposerText(payload.text);
         }
@@ -913,13 +917,14 @@ export function Chat({
           setSelectedTool(nextTool);
         }
 
-        applyComposerValueRuntimeCapabilities(payload);
+        applyComposerValueRuntimeCapabilities(
+          payload,
+          shouldInsertRuntimeCapabilitiesBeforeText
+            ? { insertAt: 0 }
+            : undefined,
+        );
       },
-      [
-        applyComposerValueRuntimeCapabilities,
-        composer?.tools,
-        setComposerText,
-      ],
+      [applyComposerValueRuntimeCapabilities, composer?.tools, setComposerText],
     ),
     onSetRuntimeCapabilities: React.useCallback(
       (selection: RuntimeCapabilitiesSelection | null) => {

--- a/packages/chatkit-ui/src/components/chat/runtime-capabilities.test.tsx
+++ b/packages/chatkit-ui/src/components/chat/runtime-capabilities.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { RuntimeCapabilityOption } from '../../lib/runtime-capabilities';
+import { HumanRuntimeCapabilityChips } from './runtime-capabilities';
+
+describe('HumanRuntimeCapabilityChips', () => {
+  it('does not tint skill chips with their configured color', () => {
+    render(
+      <HumanRuntimeCapabilityChips
+        options={[
+          {
+            type: 'skill',
+            id: 'skill-documents',
+            label: 'documents',
+            color: '#2563EB',
+            capability: {
+              id: 'skill-documents',
+              workspaceId: 'workspace-1',
+              label: 'documents',
+              meta: {
+                color: '#2563EB',
+              },
+            },
+          } satisfies RuntimeCapabilityOption,
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('documents').parentElement).not.toHaveStyle({
+      color: '#2563EB',
+    });
+  });
+
+  it('keeps configured colors for non-skill chips', () => {
+    render(
+      <HumanRuntimeCapabilityChips
+        options={[
+          {
+            type: 'plugin',
+            id: 'plugin-sandbox',
+            label: 'sandbox',
+            color: '#F97316',
+            capability: {
+              nodeKey: 'plugin-sandbox',
+              provider: 'sandbox',
+              label: 'sandbox',
+              meta: {
+                color: '#F97316',
+              },
+            },
+          } satisfies RuntimeCapabilityOption,
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('sandbox').parentElement).toHaveStyle({
+      color: '#F97316',
+    });
+  });
+});

--- a/packages/chatkit-ui/src/components/chat/runtime-capabilities.tsx
+++ b/packages/chatkit-ui/src/components/chat/runtime-capabilities.tsx
@@ -8,6 +8,7 @@ import {
   createDefaultRuntimeCapabilitiesSelection,
   createRuntimeCapabilitiesForSubmit,
   getRecommendedRuntimeCapabilitiesSelection,
+  getRuntimeCapabilityColor,
   getRuntimeCapabilityOptions,
   isRuntimeCapabilitySelected,
   mergeRuntimeCapabilitiesSelections,
@@ -23,6 +24,7 @@ import {
 } from '../../lib/conversation-runtime-capabilities';
 import {
   createComposerCapabilityPart,
+  createComposerTextParts,
   getComposerCapabilityKeys,
   getComposerCapabilitySelectionKeys,
   getComposerEditingLength,
@@ -81,6 +83,15 @@ type RuntimeCapabilitiesComposerActionsParams = {
   commitComposerParts: CommitComposerParts;
   focusComposerAt: (position?: number) => void;
 };
+
+function createComposerCapabilityInsertionParts(
+  options: RuntimeCapabilityOption[],
+): ComposerPart[] {
+  return options.flatMap((option) => [
+    createComposerCapabilityPart(option, createMessageId()),
+    ...(option.type === 'skill' ? createComposerTextParts(' ') : []),
+  ]);
+}
 
 function getHttpStatus(error: unknown): number | null {
   if (!error || typeof error !== 'object' || !('status' in error)) {
@@ -571,11 +582,16 @@ export function useRuntimeCapabilityComposerActions({
   commitComposerParts,
   focusComposerAt,
 }: RuntimeCapabilitiesComposerActionsParams) {
-  const pendingExternalRuntimeCapabilityInsertRef =
-    React.useRef<RuntimeCapabilitiesSelection | null>(null);
+  const pendingExternalRuntimeCapabilityInsertRef = React.useRef<{
+    selection: RuntimeCapabilitiesSelection;
+    insertAt?: number | null;
+  } | null>(null);
 
   const insertExternalRuntimeCapabilities = React.useCallback(
-    (selection: RuntimeCapabilitiesSelection | null) => {
+    (
+      selection: RuntimeCapabilitiesSelection | null,
+      options?: { insertAt?: number | null },
+    ) => {
       applyExternalRuntimeCapabilities(selection);
       if (!selection) {
         pendingExternalRuntimeCapabilityInsertRef.current = null;
@@ -583,7 +599,10 @@ export function useRuntimeCapabilityComposerActions({
       }
 
       if (!runtimeCapabilitiesReady || !runtimeCapabilities) {
-        pendingExternalRuntimeCapabilityInsertRef.current = selection;
+        pendingExternalRuntimeCapabilityInsertRef.current = {
+          selection,
+          insertAt: options?.insertAt ?? null,
+        };
         return;
       }
 
@@ -603,16 +622,21 @@ export function useRuntimeCapabilityComposerActions({
       }
 
       const currentParts = composerPartsRef.current;
-      const insertAt = getComposerEditingLength(currentParts);
+      const editingLength = getComposerEditingLength(currentParts);
+      const insertAt =
+        typeof options?.insertAt === 'number'
+          ? Math.max(0, Math.min(options.insertAt, editingLength))
+          : editingLength;
+      const replacementParts =
+        createComposerCapabilityInsertionParts(selectedOptions);
       const nextParts = replaceComposerRange(
         currentParts,
         insertAt,
         insertAt,
-        selectedOptions.map((option) =>
-          createComposerCapabilityPart(option, createMessageId()),
-        ),
+        replacementParts,
       );
-      const nextCaretOffset = insertAt + selectedOptions.length;
+      const nextCaretOffset =
+        insertAt + getComposerEditingLength(replacementParts);
       commitComposerParts(nextParts, {
         caretOffset: nextCaretOffset,
         resetDom: true,
@@ -634,22 +658,26 @@ export function useRuntimeCapabilityComposerActions({
   );
 
   const applyComposerValueRuntimeCapabilities = React.useCallback(
-    (payload: {
-      runtimeCapabilities?: RuntimeCapabilitiesSelection | null;
-      insertRuntimeCapabilities?: boolean;
-    }) => {
-      const runtimeCapabilitiesPayload =
-        isRuntimeCapabilitiesSelection(payload.runtimeCapabilities)
-          ? payload.runtimeCapabilities
-          : payload.runtimeCapabilities === null
-            ? null
-            : undefined;
+    (
+      payload: {
+        runtimeCapabilities?: RuntimeCapabilitiesSelection | null;
+        insertRuntimeCapabilities?: boolean;
+      },
+      options?: { insertAt?: number | null },
+    ) => {
+      const runtimeCapabilitiesPayload = isRuntimeCapabilitiesSelection(
+        payload.runtimeCapabilities,
+      )
+        ? payload.runtimeCapabilities
+        : payload.runtimeCapabilities === null
+          ? null
+          : undefined;
       if (runtimeCapabilitiesPayload === undefined) {
         return;
       }
 
       if (payload.insertRuntimeCapabilities === true) {
-        insertExternalRuntimeCapabilities(runtimeCapabilitiesPayload);
+        insertExternalRuntimeCapabilities(runtimeCapabilitiesPayload, options);
       } else {
         applyExternalRuntimeCapabilities(runtimeCapabilitiesPayload);
       }
@@ -700,7 +728,9 @@ export function useRuntimeCapabilityComposerActions({
       capability: RuntimeCapabilityOption,
       range?: { start: number; end: number },
     ) => {
-      const token = createComposerCapabilityPart(capability, createMessageId());
+      const replacementParts = createComposerCapabilityInsertionParts([
+        capability,
+      ]);
       const currentParts = composerPartsRef.current;
       const replaceRange = range ?? {
         start: getComposerEditingLength(currentParts),
@@ -710,10 +740,12 @@ export function useRuntimeCapabilityComposerActions({
         currentParts,
         replaceRange.start,
         replaceRange.end,
-        [token],
+        replacementParts,
       );
+      const nextCaretOffset =
+        replaceRange.start + getComposerEditingLength(replacementParts);
       commitComposerParts(nextParts, {
-        caretOffset: replaceRange.start + 1,
+        caretOffset: nextCaretOffset,
         resetDom: true,
         syncRemovedCapabilityTokens: true,
       });
@@ -726,7 +758,7 @@ export function useRuntimeCapabilityComposerActions({
         ),
       );
       setRuntimeCapabilityPalette(null);
-      focusComposerAt(replaceRange.start + 1);
+      focusComposerAt(nextCaretOffset);
     },
     [
       commitComposerParts,
@@ -747,7 +779,9 @@ export function useRuntimeCapabilityComposerActions({
       return;
     }
 
-    insertExternalRuntimeCapabilities(pendingSelection);
+    insertExternalRuntimeCapabilities(pendingSelection.selection, {
+      insertAt: pendingSelection.insertAt,
+    });
   }, [
     insertExternalRuntimeCapabilities,
     runtimeCapabilities,
@@ -774,15 +808,22 @@ export function HumanRuntimeCapabilityChips({
 
   return (
     <div className="mb-2 flex flex-wrap gap-1.5">
-      {options.map((option) => (
-        <span
-          key={`${option.type}:${option.id}`}
-          className="inline-flex max-w-full items-center gap-1 rounded-md bg-primary-foreground/20 px-2 py-1 text-xs font-medium text-primary-foreground"
-        >
-          <RuntimeCapabilityIcon option={option} variant="chip" />
-          <span className="max-w-[9rem] truncate">{option.label}</span>
-        </span>
-      ))}
+      {options.map((option) => {
+        const color =
+          option.type === 'skill'
+            ? undefined
+            : getRuntimeCapabilityColor(option);
+        return (
+          <span
+            key={`${option.type}:${option.id}`}
+            className="inline-flex max-w-full items-center gap-1 rounded-md bg-primary-foreground/20 px-2 py-1 text-xs font-medium text-primary-foreground"
+            style={color ? { color } : undefined}
+          >
+            <RuntimeCapabilityIcon option={option} variant="chip" />
+            <span className="max-w-[9rem] truncate">{option.label}</span>
+          </span>
+        );
+      })}
     </div>
   );
 }
@@ -805,24 +846,28 @@ export function DetachedRunRuntimeCapabilities({
   return (
     <div className="mb-2 flex flex-wrap items-center gap-2">
       <span className="text-xs text-muted-foreground">{runOnlyLabel}</span>
-      {options.map((option) => (
-        <span
-          key={`${option.type}:${option.id}`}
-          className="inline-flex max-w-full items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
-        >
-          <RuntimeCapabilityIcon option={option} variant="chip" />
-          <span className="max-w-40 truncate">{option.label}</span>
-          <button
-            type="button"
-            onClick={() => onRemove(option)}
-            className="rounded-full p-0.5 hover:bg-primary/15"
-            title={removeLabel}
-            aria-label={removeLabel}
+      {options.map((option) => {
+        const color = getRuntimeCapabilityColor(option);
+        return (
+          <span
+            key={`${option.type}:${option.id}`}
+            className="inline-flex max-w-full items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+            style={color ? { color } : undefined}
           >
-            <X size={11} />
-          </button>
-        </span>
-      ))}
+            <RuntimeCapabilityIcon option={option} variant="chip" />
+            <span className="max-w-40 truncate">{option.label}</span>
+            <button
+              type="button"
+              onClick={() => onRemove(option)}
+              className="rounded-full p-0.5 hover:bg-primary/15"
+              title={removeLabel}
+              aria-label={removeLabel}
+            >
+              <X size={11} />
+            </button>
+          </span>
+        );
+      })}
     </div>
   );
 }
@@ -832,6 +877,7 @@ export function ComposerCapabilityToken({
 }: {
   part: ComposerCapabilityPart;
 }) {
+  const color = getRuntimeCapabilityColor(part.capability);
   return (
     <span
       key={part.key}
@@ -840,6 +886,7 @@ export function ComposerCapabilityToken({
       data-capability-id={part.capability.id}
       contentEditable={false}
       className="mx-0.5 inline-flex max-w-[14rem] select-none items-center gap-1 text-sm font-semibold text-primary align-baseline"
+      style={color ? { color } : undefined}
     >
       <RuntimeCapabilityIcon option={part.capability} variant="chip" />
       <span className="truncate">{part.capability.label}</span>

--- a/packages/chatkit-ui/src/components/composer/ComposerMenu.test.tsx
+++ b/packages/chatkit-ui/src/components/composer/ComposerMenu.test.tsx
@@ -250,6 +250,7 @@ describe('ComposerMenu', () => {
               label: 'Research Skill',
               description: 'Search and summarize',
               meta: {
+                color: '#2563EB',
                 icon: {
                   type: 'svg',
                   value:
@@ -265,6 +266,7 @@ describe('ComposerMenu', () => {
               label: 'Sandbox Plugin',
               description: 'Run commands',
               meta: {
+                color: '#F97316',
                 icon: {
                   type: 'svg',
                   value:
@@ -322,6 +324,9 @@ describe('ComposerMenu', () => {
     expect(
       skillItem.querySelector('[data-slot="runtime-capability-meta-icon"] svg'),
     ).toBeInTheDocument();
+    expect(within(skillItem).getByText('Research Skill')).not.toHaveStyle({
+      color: '#2563EB',
+    });
     fireEvent.click(skillItem);
     expect(onRuntimeCapabilityToggle).toHaveBeenCalledWith(
       'skill',
@@ -339,6 +344,9 @@ describe('ComposerMenu', () => {
         '[data-slot="runtime-capability-meta-icon"] svg',
       ),
     ).toBeInTheDocument();
+    expect(within(pluginItem).getByText('Sandbox Plugin')).toHaveStyle({
+      color: '#F97316',
+    });
     fireEvent.click(pluginItem);
     expect(onRuntimeCapabilityToggle).toHaveBeenCalledWith(
       'plugin',

--- a/packages/chatkit-ui/src/components/composer/ComposerMenu.tsx
+++ b/packages/chatkit-ui/src/components/composer/ComposerMenu.tsx
@@ -47,6 +47,7 @@ import {
 import { useChatkitTranslation } from '../../i18n/useChatkitTranslation';
 import { useTheme } from '../../providers/Theme';
 import {
+  getRuntimeCapabilityColor,
   isRuntimeCapabilitySelected,
   type RuntimeCapabilitiesSelection,
   type RuntimeCapabilityOption,
@@ -324,6 +325,8 @@ export function ComposerMenu({
     const selected = selectedRuntimeCapabilities
       ? isRuntimeCapabilitySelected(selectedRuntimeCapabilities, type, item.id)
       : false;
+    const capabilityColor =
+      type === 'skill' ? undefined : getRuntimeCapabilityColor(item.capability);
     const icon = (
       <RuntimeCapabilityIcon option={item.capability} variant="list" />
     );
@@ -342,11 +345,19 @@ export function ComposerMenu({
           selected && 'bg-muted',
         )}
       >
-        <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center text-muted-foreground">
+        <span
+          className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center text-muted-foreground"
+          style={capabilityColor ? { color: capabilityColor } : undefined}
+        >
           {icon}
         </span>
         <span className="min-w-0 flex-1 text-left">
-          <span className="block truncate">{item.label}</span>
+          <span
+            className="block truncate"
+            style={capabilityColor ? { color: capabilityColor } : undefined}
+          >
+            {item.label}
+          </span>
           {(item.description || item.fallbackDescription) && (
             <span className="block truncate text-xs text-muted-foreground">
               {item.description ?? item.fallbackDescription}

--- a/packages/chatkit-ui/src/components/composer/SlashPalette.test.tsx
+++ b/packages/chatkit-ui/src/components/composer/SlashPalette.test.tsx
@@ -98,4 +98,42 @@ describe('SlashPalette', () => {
 
     expect(badge).toHaveAttribute('data-slot', 'slash-palette-child-count');
   });
+
+  it('does not tint skill capability rows with the skill color', () => {
+    render(
+      <SlashPalette
+        palette={palette}
+        options={[
+          {
+            kind: 'capability',
+            id: 'capability:skill:documents',
+            label: 'documents',
+            capability: {
+              type: 'skill',
+              id: 'skill-docs',
+              label: 'documents',
+              capability: {
+                id: 'skill-docs',
+                workspaceId: 'workspace-1',
+                label: 'documents',
+                meta: {
+                  color: '#2563EB',
+                },
+              },
+            },
+            depth: 1,
+          },
+        ]}
+        paletteRef={{ current: null }}
+        optionRefs={{ current: [] }}
+        emptyLabel="No commands"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const option = screen.getByRole('button', { name: /documents/ });
+    expect(within(option).getByText('documents')).not.toHaveStyle({
+      color: '#2563EB',
+    });
+  });
 });

--- a/packages/chatkit-ui/src/components/composer/SlashPalette.tsx
+++ b/packages/chatkit-ui/src/components/composer/SlashPalette.tsx
@@ -16,6 +16,7 @@ import type {
   SlashPaletteOption,
 } from '../../lib/slash-commands';
 import type { RuntimeCapabilityOption } from '../../lib/runtime-capabilities';
+import { getRuntimeCapabilityColor } from '../../lib/runtime-capabilities';
 import { RuntimeCapabilityIcon } from '../runtime-capability-icon';
 import { IconDefinitionRenderer } from '../ui/icon-definition';
 
@@ -83,92 +84,111 @@ export function SlashPalette({
       )}
     >
       {options.length > 0 ? (
-        options.map((option, index) => (
-          <React.Fragment key={option.id}>
-            <button
-              ref={(element) => {
-                optionRefs.current[index] = element;
-              }}
-              data-slot="slash-palette-option"
-              data-kind={option.kind}
-              data-depth={option.kind === 'capability' ? option.depth : 0}
-              type="button"
-              aria-expanded={
-                option.kind === 'command' && option.capabilityType
-                  ? option.expanded === true
-                  : undefined
-              }
-              onMouseDown={(event) => {
-                event.preventDefault();
-                onSelect(option);
-              }}
-              className={cn(
-                'flex h-8 w-full items-center gap-1 rounded-md px-2 text-left text-sm hover:bg-muted',
-                itemRoundedClass,
-                option.kind === 'capability' && option.depth === 1 && 'pl-9',
-                index === palette.activeIndex && 'bg-muted',
-              )}
-            >
-              <span
+        options.map((option, index) => {
+          const capabilityColor =
+            option.kind === 'capability' && option.capability.type !== 'skill'
+              ? getRuntimeCapabilityColor(option.capability)
+              : undefined;
+          return (
+            <React.Fragment key={option.id}>
+              <button
+                ref={(element) => {
+                  optionRefs.current[index] = element;
+                }}
+                data-slot="slash-palette-option"
+                data-kind={option.kind}
+                data-depth={option.kind === 'capability' ? option.depth : 0}
+                type="button"
+                aria-expanded={
+                  option.kind === 'command' && option.capabilityType
+                    ? option.expanded === true
+                    : undefined
+                }
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  onSelect(option);
+                }}
                 className={cn(
-                  'flex h-6 w-6 shrink-0 items-center justify-center text-muted-foreground',
+                  'flex h-8 w-full items-center gap-1 rounded-md px-2 text-left text-sm hover:bg-muted',
+                  itemRoundedClass,
                   option.kind === 'capability' &&
                     option.depth === 1 &&
-                    'h-5 w-5',
+                    'pl-9',
+                  index === palette.activeIndex && 'bg-muted',
                 )}
               >
-                {option.kind === 'command' ? (
-                  <SlashCommandIcon command={option.command} />
-                ) : (
-                  <RuntimeCapabilityIcon
-                    option={option.capability}
-                    variant="list"
-                  />
-                )}
-              </span>
-              <span className="flex min-w-0 flex-1 items-baseline gap-2">
-                <span className="flex min-w-0 shrink-0 items-baseline gap-1.5">
-                  <span className="truncate font-medium">{option.label}</span>
-                  {option.kind === 'command' &&
-                  option.capabilityType &&
-                  typeof option.childCount === 'number' ? (
-                    <span
-                      data-slot="slash-palette-child-count"
-                      className="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-muted px-1 text-[10px] font-medium leading-none text-muted-foreground"
-                    >
-                      {option.childCount}
-                    </span>
-                  ) : null}
-                </span>
-                {option.description && (
-                  <span className="min-w-0 flex-1 truncate text-muted-foreground">
-                    {option.description}
-                  </span>
-                )}
-              </span>
-              {option.kind === 'command' && option.capabilityType ? (
-                <span className="flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground">
-                  {option.expanded ? (
-                    <ChevronDown size={14} />
+                <span
+                  className={cn(
+                    'flex h-6 w-6 shrink-0 items-center justify-center text-muted-foreground',
+                    option.kind === 'capability' &&
+                      option.depth === 1 &&
+                      'h-5 w-5',
+                  )}
+                  style={
+                    capabilityColor ? { color: capabilityColor } : undefined
+                  }
+                >
+                  {option.kind === 'command' ? (
+                    <SlashCommandIcon command={option.command} />
                   ) : (
-                    <ChevronRight size={14} />
+                    <RuntimeCapabilityIcon
+                      option={option.capability}
+                      variant="list"
+                    />
                   )}
                 </span>
+                <span className="flex min-w-0 flex-1 items-baseline gap-2">
+                  <span className="flex min-w-0 shrink-0 items-baseline gap-1.5">
+                    <span
+                      className="truncate font-medium"
+                      style={
+                        capabilityColor ? { color: capabilityColor } : undefined
+                      }
+                    >
+                      {option.label}
+                    </span>
+                    {option.kind === 'command' &&
+                    option.capabilityType &&
+                    typeof option.childCount === 'number' ? (
+                      <span
+                        data-slot="slash-palette-child-count"
+                        className="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-muted px-1 text-[10px] font-medium leading-none text-muted-foreground"
+                      >
+                        {option.childCount}
+                      </span>
+                    ) : null}
+                  </span>
+                  {option.description && (
+                    <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                      {option.description}
+                    </span>
+                  )}
+                </span>
+                {option.kind === 'command' && option.capabilityType ? (
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground">
+                    {option.expanded ? (
+                      <ChevronDown size={14} />
+                    ) : (
+                      <ChevronRight size={14} />
+                    )}
+                  </span>
+                ) : null}
+              </button>
+              {option.kind === 'command' &&
+              option.capabilityType &&
+              option.expanded &&
+              option.childCount === 0 ? (
+                <div
+                  data-slot="slash-palette-group-empty"
+                  className="px-3 py-1.5 pl-12 text-xs text-muted-foreground"
+                >
+                  {capabilityEmptyLabels?.[option.capabilityType] ??
+                    emptyLabel}
+                </div>
               ) : null}
-            </button>
-            {option.kind === 'command' &&
-            option.capabilityType &&
-            option.expanded &&
-            option.childCount === 0 ? (
-              <div
-                data-slot="slash-palette-group-empty"
-                className="px-3 py-1.5 pl-12 text-xs text-muted-foreground"
-              >
-                {capabilityEmptyLabels?.[option.capabilityType] ?? emptyLabel}
-              </div>
-            ) : null}
-          </React.Fragment>
-        ))
+            </React.Fragment>
+          );
+        })
       ) : (
         <div className="px-3 py-2 text-sm text-muted-foreground">
           {emptyLabel}

--- a/packages/chatkit-ui/src/lib/runtime-capabilities.ts
+++ b/packages/chatkit-ui/src/lib/runtime-capabilities.ts
@@ -29,6 +29,7 @@ export type RuntimeCapabilityOption =
       id: string;
       label: string;
       description?: string;
+      color?: string;
       capability: RuntimeCapabilitySkill;
     }
   | {
@@ -36,6 +37,7 @@ export type RuntimeCapabilityOption =
       id: string;
       label: string;
       description?: string;
+      color?: string;
       capability: RuntimeCapabilityPlugin;
     }
   | {
@@ -43,6 +45,7 @@ export type RuntimeCapabilityOption =
       id: string;
       label: string;
       description?: string;
+      color?: string;
       capability: RuntimeCapabilitySubAgent;
     };
 
@@ -269,6 +272,7 @@ export function getRuntimeCapabilityOptions(
       id: capability.id,
       label: capability.label,
       description: capability.description ?? capability.repositoryName,
+      color: readRuntimeCapabilityColor(capability),
       capability,
     })),
     ...capabilities.plugins.map((capability) => ({
@@ -276,6 +280,7 @@ export function getRuntimeCapabilityOptions(
       id: capability.nodeKey,
       label: capability.label,
       description: capability.description ?? capability.provider,
+      color: readRuntimeCapabilityColor(capability),
       capability,
     })),
     ...(capabilities.subAgents ?? []).map((capability) => ({
@@ -283,9 +288,35 @@ export function getRuntimeCapabilityOptions(
       id: capability.nodeKey,
       label: capability.label,
       description: capability.description ?? capability.name,
+      color: readRuntimeCapabilityColor(capability),
       capability,
     })),
   ];
+}
+
+export function getRuntimeCapabilityColor(
+  option?: RuntimeCapabilityOption | null,
+): string | undefined {
+  return option?.color ?? readRuntimeCapabilityColor(option?.capability);
+}
+
+function readRuntimeCapabilityColor(capability: unknown): string | undefined {
+  const meta = readObjectValue(capability)?.meta;
+  const color = readNonEmptyString(readObjectValue(meta)?.color);
+  if (color) {
+    return color;
+  }
+  return readNonEmptyString(readObjectValue(meta)?.brandColor);
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function readObjectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
 }
 
 export function hasRuntimeCapabilitySelection(

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,9 @@ packages:
   - 'packages/*'
   - 'examples/*'
   - 'examples/*/*'
+allowBuilds:
+  '@parcel/watcher': set this to true or false
+  esbuild: set this to true or false
+  msw: set this to true or false
 gitChecks: false
 publishBranch: main


### PR DESCRIPTION
## Summary

- Add runtime capability color metadata support and render configured colors on composer-inserted capability tokens where appropriate.
- Keep skill entries visually neutral in runtime capability list/menu surfaces and sent-message chips, while preserving color support for non-skill capability indicators.
- Ensure externally inserted runtime capabilities are inserted before composer text and add a trailing space after inserted skill chips.
- Add focused tests for runtime capability insertion, skill color handling, ComposerMenu, SlashPalette, and plan mode behavior.
- Add changesets for the published ChatKit package updates.

## Validation

- `corepack pnpm -F @xpert-ai/chatkit-ui test` — passed, 50 files / 412 tests.
- `corepack pnpm -F @xpert-ai/chatkit-ui types` — passed.
- `corepack pnpm -r run types` — blocked in `@xpert-ai/chatkit-web-shared` by an existing `ImportMetaEnv.DEV` declaration conflict with Vite types; the related import-meta declaration file is unchanged in this PR.
