### PR TITLE
[codex] refine task summary and message attachments

### DIFF
--- a/.changeset/bright-agents-report.md
+++ b/.changeset/bright-agents-report.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/chatkit-ui': patch
+---
+
+Hide primary agent executions from agent activity.

--- a/.changeset/calm-task-summary-actions.md
+++ b/.changeset/calm-task-summary-actions.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/chatkit-ui': patch
+---
+
+Remove inactive output and source action buttons from the task summary.

--- a/.changeset/quiet-images-appear-once.md
+++ b/.changeset/quiet-images-appear-once.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/chatkit-ui': patch
+---
+
+Deduplicate human message attachments already displayed as image references.

--- a/packages/chatkit-ui/src/components/chat.tsx
+++ b/packages/chatkit-ui/src/components/chat.tsx
@@ -64,6 +64,7 @@ import {
   type ChatAttachmentsState,
 } from './chat/attachments';
 import { UploadDroppedFiles } from './chat/upload-dropped-files';
+import { getVisibleHumanAttachments } from './chat/message-files';
 import { usePetAutoState } from './chat/usePetAutoState';
 import { useSlashCommands } from './chat/useSlashCommands';
 import {
@@ -3011,10 +3012,13 @@ export function Chat({
                 messageContent.trim().length > 0;
               const humanMessage = message as HumanMessageWithMeta;
               const humanReferences = humanMessage.references ?? [];
-              const humanAttachments = [
-                ...(humanMessage.fileAssets ?? []),
-                ...(humanMessage.attachments ?? []),
-              ];
+              const humanAttachments = getVisibleHumanAttachments(
+                [
+                  ...(humanMessage.fileAssets ?? []),
+                  ...(humanMessage.attachments ?? []),
+                ],
+                humanReferences,
+              );
               const humanRuntimeCapabilityOptions =
                 message.type === 'human'
                   ? (humanMessage.runtimeCapabilityOptions ??

--- a/packages/chatkit-ui/src/components/chat/message-files.test.ts
+++ b/packages/chatkit-ui/src/components/chat/message-files.test.ts
@@ -1,0 +1,57 @@
+import type { ChatKitReference } from '@xpert-ai/chatkit-types';
+import { describe, expect, it } from 'vitest';
+
+import type { ChatAttachmentFile } from './attachments';
+import { getVisibleHumanAttachments } from './message-files';
+
+describe('getVisibleHumanAttachments', () => {
+  it('hides file representations already shown as an image reference', () => {
+    const references: ChatKitReference[] = [
+      {
+        type: 'image',
+        id: 'image-reference-1',
+        fileId: 'storage-image-1',
+        url: 'https://files.example/image.png',
+        text: 'Pasted image: image.png',
+      },
+    ];
+    const attachments: ChatAttachmentFile[] = [
+      {
+        id: 'image-asset-1',
+        fileId: 'image-asset-1',
+        storageFileId: 'storage-image-1',
+        originalName: 'image.png',
+      },
+      {
+        id: 'storage-image-1',
+        originalName: 'image.png',
+      },
+      {
+        id: 'document-asset-1',
+        originalName: 'brief.pdf',
+      },
+    ];
+
+    expect(getVisibleHumanAttachments(attachments, references)).toEqual([
+      expect.objectContaining({ id: 'document-asset-1' }),
+    ]);
+  });
+
+  it('deduplicates FileAsset and legacy attachment representations', () => {
+    const attachments: ChatAttachmentFile[] = [
+      {
+        id: 'asset-1',
+        storageFileId: 'storage-1',
+        originalName: 'brief.pdf',
+      },
+      {
+        id: 'storage-1',
+        originalName: 'brief.pdf',
+      },
+    ];
+
+    expect(getVisibleHumanAttachments(attachments, [])).toEqual([
+      expect.objectContaining({ id: 'asset-1' }),
+    ]);
+  });
+});

--- a/packages/chatkit-ui/src/components/chat/message-files.ts
+++ b/packages/chatkit-ui/src/components/chat/message-files.ts
@@ -1,0 +1,66 @@
+import type { ChatKitReference } from '@xpert-ai/chatkit-types';
+
+import type { ChatAttachmentFile } from './attachments';
+
+function addIdentity(identities: Set<string>, value?: string) {
+  const identity = value?.trim();
+  if (identity) {
+    identities.add(identity);
+  }
+}
+
+function getAttachmentIdentities(file: ChatAttachmentFile) {
+  const identities = new Set<string>();
+  addIdentity(identities, file.id);
+  addIdentity(identities, file.fileId);
+  addIdentity(identities, file.storageFileId);
+  addIdentity(identities, file.url);
+  addIdentity(identities, file.fileUrl);
+  addIdentity(identities, file.thumbUrl);
+  return identities;
+}
+
+function getImageReferenceIdentities(references: ChatKitReference[]) {
+  const identities = new Set<string>();
+
+  references.forEach((reference) => {
+    if (reference.type !== 'image') {
+      return;
+    }
+    addIdentity(identities, reference.id);
+    addIdentity(identities, reference.fileId);
+    addIdentity(identities, reference.url);
+  });
+
+  return identities;
+}
+
+export function getVisibleHumanAttachments(
+  attachments: ChatAttachmentFile[],
+  references: ChatKitReference[],
+) {
+  const imageReferenceIdentities = getImageReferenceIdentities(references);
+  const visibleAttachmentIdentities = new Set<string>();
+
+  return attachments.filter((attachment) => {
+    const identities = getAttachmentIdentities(attachment);
+    const isImageReference = [...identities].some((identity) =>
+      imageReferenceIdentities.has(identity),
+    );
+    if (isImageReference) {
+      return false;
+    }
+
+    const isDuplicate = [...identities].some((identity) =>
+      visibleAttachmentIdentities.has(identity),
+    );
+    if (isDuplicate) {
+      return false;
+    }
+
+    identities.forEach((identity) =>
+      visibleAttachmentIdentities.add(identity),
+    );
+    return true;
+  });
+}

--- a/packages/chatkit-ui/src/components/task-summary/TaskSummary.test.tsx
+++ b/packages/chatkit-ui/src/components/task-summary/TaskSummary.test.tsx
@@ -101,7 +101,7 @@ describe('TaskSummaryTrigger', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it('keeps Codex-style output and source actions visible when empty', () => {
+  it('keeps the empty output prompt without inactive section actions', () => {
     const onFocusComposer = vi.fn();
     const value = summary();
     value.outputs = [];
@@ -121,9 +121,14 @@ describe('TaskSummaryTrigger', () => {
     );
 
     expect(screen.getByText('Create files or sites')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Create output' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Add source' }));
-    expect(onFocusComposer).toHaveBeenCalledTimes(2);
+    expect(
+      screen.queryByRole('button', { name: 'Create output' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Add source' }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Create files or sites'));
+    expect(onFocusComposer).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/chatkit-ui/src/components/task-summary/TaskSummary.tsx
+++ b/packages/chatkit-ui/src/components/task-summary/TaskSummary.tsx
@@ -9,7 +9,6 @@ import {
   ListChecks,
   Loader2,
   PlayCircle,
-  Plus,
   RotateCcw,
   Target,
 } from 'lucide-react';
@@ -20,7 +19,6 @@ import type {
 } from '../../lib/task-summary';
 import { useChatkitTranslation } from '../../i18n/useChatkitTranslation';
 import { cn } from '../../lib/utils';
-import { Button } from '../ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 
@@ -221,8 +219,6 @@ function TaskSummaryContent({
 
       <SummarySection
         title={t('taskSummary.sections.outputs')}
-        actionLabel={t('taskSummary.addOutput')}
-        onAction={onFocusComposer}
       >
         {summary.outputs.length === 0 ? (
           <SummaryPrompt onClick={onFocusComposer}>
@@ -251,8 +247,6 @@ function TaskSummaryContent({
 
       <SummarySection
         title={t('taskSummary.sections.sources')}
-        actionLabel={t('taskSummary.addSource')}
-        onAction={onFocusComposer}
       >
         {sectionItems('sources', summary.sources).map((item) => (
           <SummaryButton
@@ -384,31 +378,15 @@ function TaskSummaryContent({
 
 function SummarySection({
   title,
-  actionLabel,
-  onAction,
   children,
 }: {
   title: string;
-  actionLabel?: string;
-  onAction?: () => void;
   children: React.ReactNode;
 }) {
   return (
     <section aria-label={title} className="px-4 py-3">
       <div className="flex min-h-7 items-center justify-between gap-3">
         <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>
-        {onAction && actionLabel && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            className="size-7 rounded-lg bg-muted/60 text-muted-foreground hover:bg-muted hover:text-foreground"
-            aria-label={actionLabel}
-            onClick={onAction}
-          >
-            <Plus className="size-4" />
-          </Button>
-        )}
       </div>
       <div className="mt-1 space-y-0.5">{children}</div>
     </section>

--- a/packages/chatkit-ui/src/lib/task-summary.test.ts
+++ b/packages/chatkit-ui/src/lib/task-summary.test.ts
@@ -118,7 +118,7 @@ describe('task summary aggregation', () => {
     ]);
   });
 
-  it('shows invoked agents by configured name without treating available agents as sources', () => {
+  it('shows only invoked sub-agents by configured name without treating available agents as sources', () => {
     const live = collectLiveTaskSummary({
       messages: [
         {
@@ -141,7 +141,15 @@ describe('task summary aggregation', () => {
           },
           agentRuns: [
             {
+              id: 'root-execution',
+              agentKey: 'Agent_primary',
+              title: 'Primary Agent',
+              status: 'running',
+              updatedAt: '2026-07-13T03:00:00.000Z',
+            },
+            {
               id: 'execution-1',
+              parentId: 'root-execution',
               agentKey: 'Agent_wzkLtrU4Ai',
               title: 'Diagnosis Runner',
               status: 'error',
@@ -149,6 +157,7 @@ describe('task summary aggregation', () => {
             },
             {
               id: 'execution-2',
+              parentId: 'root-execution',
               agentKey: 'Agent_wzkLtrU4Ai',
               title: 'Diagnosis Runner',
               status: 'running',
@@ -203,6 +212,38 @@ describe('task summary aggregation', () => {
 
     expect(merged.agents).toEqual([
       expect.objectContaining({ id: 'execution-2', status: 'running' }),
+    ]);
+    expect(merged.totals.agents).toBe(1);
+  });
+
+  it('excludes primary agent executions from historical summaries', () => {
+    const history = snapshot({
+      agents: {
+        total: 2,
+        items: [
+          {
+            id: 'root-execution',
+            level: 0,
+            agentKey: 'Agent_primary',
+            title: 'Primary Agent',
+            status: 'success',
+          },
+          {
+            id: 'child-execution',
+            parentId: 'root-execution',
+            level: 1,
+            agentKey: 'Agent_researcher',
+            title: 'Researcher',
+            status: 'success',
+          },
+        ],
+      },
+    });
+
+    const merged = mergeTaskSummary(history, emptyLive({}));
+
+    expect(merged.agents).toEqual([
+      expect.objectContaining({ id: 'child-execution' }),
     ]);
     expect(merged.totals.agents).toBe(1);
   });

--- a/packages/chatkit-ui/src/lib/task-summary.ts
+++ b/packages/chatkit-ui/src/lib/task-summary.ts
@@ -645,24 +645,26 @@ export function collectLiveTaskSummary({
     (message) => extractPlan(message) ?? [],
   );
   const agentRuns = messages.flatMap((message) =>
-    (message.agentRuns ?? []).map((run) => ({
-      id: run.id,
-      parentId: run.parentId,
-      level: agentRunLevel(run, messages),
-      agentKey: run.agentKey,
-      title:
-        (run.agentKey ? agentNames?.get(run.agentKey) : undefined) ??
-        run.title ??
-        run.xpertName ??
-        run.agentKey ??
-        'Agent',
-      status: taskSummaryAgentStatus(run.status),
-      elapsedTime: run.elapsedTime,
-      error: typeof run.error === 'string' ? run.error : undefined,
-      messageId: message.id,
-      updatedAt:
-        run.updatedAt ?? run.endedAt ?? run.startedAt ?? message.updatedAt,
-    })),
+    (message.agentRuns ?? [])
+      .filter((run) => Boolean(run.parentId))
+      .map((run) => ({
+        id: run.id,
+        parentId: run.parentId,
+        level: agentRunLevel(run, messages),
+        agentKey: run.agentKey,
+        title:
+          (run.agentKey ? agentNames?.get(run.agentKey) : undefined) ??
+          run.title ??
+          run.xpertName ??
+          run.agentKey ??
+          'Agent',
+        status: taskSummaryAgentStatus(run.status),
+        elapsedTime: run.elapsedTime,
+        error: typeof run.error === 'string' ? run.error : undefined,
+        messageId: message.id,
+        updatedAt:
+          run.updatedAt ?? run.endedAt ?? run.startedAt ?? message.updatedAt,
+      })),
   );
   return {
     goal,
@@ -724,7 +726,9 @@ export function mergeTaskSummary(
     ...live.sources,
   ]);
   const agents = mergeAgents([
-    ...(historySections?.agents ?? history?.agents.items ?? []),
+    ...(historySections?.agents ?? history?.agents.items ?? []).filter((agent) =>
+      Boolean(agent.parentId),
+    ),
     ...live.agents,
   ]);
   const pending = mergePending([


### PR DESCRIPTION
## Summary

- show only invoked sub-agents in live and historical task summary activity
- remove inactive output and source section action buttons
- deduplicate human message attachments already represented by image references or legacy attachment records

## Problem

Task summary activity could display the primary/root agent alongside invoked sub-agents. The live aggregation and historical summary paths did not consistently enforce the root-versus-child execution boundary, so a primary agent could reappear after history loaded.

The output and source section action buttons only focused the composer and duplicated the existing empty-state prompt without providing a section-specific action.

Human message files could be rendered more than once when the same upload was present as a FileAsset, a legacy attachment, and an image reference.

## Root cause and fix

- Filter agent executions structurally using `parentId`: root executions have no parent, while child/sub-agent executions do. Apply the same rule to live runs and historical/paginated agent sections before merging.
- Remove the section-level action props and buttons while retaining the clickable empty output prompt.
- Compare stable file identities (`id`, file IDs, storage IDs, and URLs) before rendering attachments, excluding image-reference matches and duplicate file representations.

Each behavior has a focused patch changeset and regression coverage.

## Validation

- `pnpm --filter @xpert-ai/chatkit-ui test` — 54 files, 437 tests passed
- `pnpm --filter @xpert-ai/chatkit-ui types`
- `pnpm --filter @xpert-ai/chatkit-ui build`
- `git diff --check origin/main...HEAD`
- locally built and synchronized into the running `xpert-develop`; requester confirmed the updated UI behavior
