### PR TITLE
fix: bind new threads to active assistant

### DIFF
--- a/.changeset/tidy-threads-bind.md
+++ b/.changeset/tidy-threads-bind.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/chatkit-ui': patch
+---
+
+Bind new ChatKit threads to the active assistant before the first run.

--- a/packages/chatkit-ui/package.json
+++ b/packages/chatkit-ui/package.json
@@ -38,7 +38,7 @@
     "@xpert-ai/a2ui-react": "workspace:~",
     "@xpert-ai/chatkit-types": "workspace:~",
     "@xpert-ai/chatkit-web-shared": "workspace:~",
-    "@xpert-ai/xpert-sdk": "^0.0.13",
+    "@xpert-ai/xpert-sdk": "^0.0.15",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.4.9",

--- a/packages/chatkit-ui/src/providers/Stream.test.ts
+++ b/packages/chatkit-ui/src/providers/Stream.test.ts
@@ -16,6 +16,7 @@ import { createLangGraphEventState } from './langGraphEventMapper';
 import {
   applyStreamEvent,
   buildSteerFollowUpRunInput,
+  createAssistantThreadPayload,
   createConversationMessagesPageQuery,
   createLanguageHeaders,
   createFetchWithClientSecretRefresh,
@@ -36,6 +37,22 @@ import {
   resolveClientToolCallResponse,
   shouldBroadcastThreadChange,
 } from './Stream';
+
+describe('assistant thread creation', () => {
+  it('binds generated threads to the current assistant', () => {
+    expect(createAssistantThreadPayload('assistant-1')).toEqual({
+      assistantId: 'assistant-1',
+    });
+  });
+
+  it('binds caller-provided thread ids to the current assistant', () => {
+    expect(createAssistantThreadPayload('assistant-1', 'thread-1')).toEqual({
+      assistantId: 'assistant-1',
+      threadId: 'thread-1',
+      ifExists: 'raise',
+    });
+  });
+});
 
 describe('conversation message history pagination', () => {
   it('builds reverse-created-at page queries for conversation messages', () => {

--- a/packages/chatkit-ui/src/providers/Stream.tsx
+++ b/packages/chatkit-ui/src/providers/Stream.tsx
@@ -319,6 +319,16 @@ export function createLanguageHeaders(
     : undefined;
 }
 
+export function createAssistantThreadPayload(
+  assistantId: string,
+  threadId?: string,
+) {
+  return {
+    assistantId,
+    ...(threadId ? { threadId, ifExists: 'raise' as const } : {}),
+  };
+}
+
 function createAbortError(message: string): Error | DOMException {
   if (typeof DOMException !== 'undefined') {
     return new DOMException(message, 'AbortError');
@@ -3413,15 +3423,16 @@ const StreamSession = ({
         setThreadId(desiredThreadId);
       }
       if (!nextThreadId && desiredThreadId) {
-        const created = await client.threads.create({
-          threadId: desiredThreadId,
-          ifExists: 'raise',
-        });
+        const created = await client.threads.create(
+          createAssistantThreadPayload(assistantId, desiredThreadId),
+        );
         nextThreadId = created.thread_id;
         setThreadId(created.thread_id);
       }
       if (!nextThreadId) {
-        const created = await client.threads.create();
+        const created = await client.threads.create(
+          createAssistantThreadPayload(assistantId),
+        );
         nextThreadId = created.thread_id;
         setThreadId(created.thread_id);
       }
@@ -3453,6 +3464,7 @@ const StreamSession = ({
       );
     },
     [
+      assistantId,
       client,
       addAutoQueuedFollowUpIds,
       addSteerPriorityFollowUpIds,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,8 +398,8 @@ importers:
         specifier: workspace:~
         version: link:../chatkit-web-shared
       '@xpert-ai/xpert-sdk':
-        specifier: ^0.0.13
-        version: 0.0.13
+        specifier: ^0.0.15
+        version: 0.0.15
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3556,8 +3556,8 @@ packages:
   '@vue/shared@3.5.26':
     resolution: {integrity: sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==}
 
-  '@xpert-ai/xpert-sdk@0.0.13':
-    resolution: {integrity: sha512-hTmO5OLFVqRiZeuUVFAJQUIs3JGeDTTD1HcpqswPiH7BXQ9rNLEEEVFp5c8uk9EOX3SEsyxcRaaNpcOPf/kLXw==}
+  '@xpert-ai/xpert-sdk@0.0.15':
+    resolution: {integrity: sha512-l6dRBsmx0R79aygyDrPPeqgf08ABv5XsHYq5fdRuAPJq+df59mR3La4tfRyWW+egL/4aWkYXwtu9ibVu+0iLLA==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -10480,7 +10480,7 @@ snapshots:
 
   '@vue/shared@3.5.26': {}
 
-  '@xpert-ai/xpert-sdk@0.0.13':
+  '@xpert-ai/xpert-sdk@0.0.15':
     dependencies:
       p-queue: 6.6.2
       p-retry: 4.6.2


### PR DESCRIPTION
## Summary
- pass the active assistant ID when ChatKit creates generated or caller-provided threads
- upgrade `@xpert-ai/xpert-sdk` to `0.0.15`
- add regression coverage and a patch changeset

## Validation
- `corepack pnpm --filter @xpert-ai/chatkit-ui exec vitest run src/providers/Stream.test.ts`
- `corepack pnpm --filter @xpert-ai/chatkit-ui run types`
- `corepack pnpm --filter @xpert-ai/chatkit-ui exec eslint src/providers/Stream.tsx src/providers/Stream.test.ts`
- `corepack pnpm --filter @xpert-ai/chatkit-ui run build:lib`
- `git diff --check`