### PR TITLE
feat: support active runs and tool output image artifacts

### DIFF
--- a/.changeset/quiet-images-preview.md
+++ b/.changeset/quiet-images-preview.md
@@ -1,0 +1,9 @@
+---
+'@xpert-ai/chatkit-types': minor
+'@xpert-ai/chatkit-ui': minor
+'@xpert-ai/chatkit-web-component': minor
+---
+
+Add a secure Tool Output Attachment protocol for immutable model-viewed images,
+host-authorized short-lived preview resolution, inline tool-call galleries, and
+accessible full-image previews without persisting signed URLs or base64 data.

--- a/packages/chatkit-ui/src/components/thread/StartScreen.tsx
+++ b/packages/chatkit-ui/src/components/thread/StartScreen.tsx
@@ -87,16 +87,16 @@ export function StartScreen({
                   disabled={promptSendDisabled}
                   onClick={() => onPromptClick?.(item.prompt)}
                   className={cn(
-                    'flex min-w-0 flex-1 items-center gap-3 p-4 text-left',
+                    'flex min-w-0 flex-1 items-center gap-3 p-4 text-left overflow-hidden',
                     'focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
                   )}
                 >
                   <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
                     {getIconComponent(item.icon)}
                   </span>
-                  <span className="text-sm font-medium text-foreground">
+                  <div className="text-sm font-medium text-foreground line-clamp-3 overflow-hidden" title={item.label}>
                     {item.label}
-                  </span>
+                  </div>
                 </button>
                 <button
                   type="button"

--- a/packages/chatkit-ui/src/components/thread/messages/ai.test.tsx
+++ b/packages/chatkit-ui/src/components/thread/messages/ai.test.tsx
@@ -537,6 +537,41 @@ describe('AssistantMessage tool components', () => {
     expect(screen.getByText('file contents')).toBeInTheDocument();
   });
 
+  it('renders immutable tool-output image artifacts before the raw output', () => {
+    renderAssistant([
+      createToolComponent('knowledge_document_view_images', {
+        output: {
+          message: 'The image will be attached to the next model step.',
+        },
+        artifact: {
+          type: 'xpert.tool-output',
+          version: 1,
+          attachments: [
+            {
+              type: 'image',
+              artifactId: 'artifact-1',
+              artifactVersionId: 'version-1',
+              sha256: 'a'.repeat(64),
+              mimeType: 'image/png',
+              title: 'Picture 1 on page 75',
+              source: 'knowledge-document',
+              modelDetail: 'high',
+            },
+          ],
+        },
+      }),
+    ]);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /knowledge_document_view_images/ }),
+    );
+
+    expect(screen.getByTestId('tool-output-attachments')).toBeInTheDocument();
+    expect(
+      screen.getByText(/The image will be attached to the next model step/),
+    ).toBeInTheDocument();
+  });
+
   it('shows the stable tool name before the input label when the row uses a summary title', () => {
     renderAssistant([
       createToolComponent('bom_lifecycle_save_observation', {

--- a/packages/chatkit-ui/src/components/thread/messages/ai.test.tsx
+++ b/packages/chatkit-ui/src/components/thread/messages/ai.test.tsx
@@ -537,6 +537,28 @@ describe('AssistantMessage tool components', () => {
     expect(screen.getByText('file contents')).toBeInTheDocument();
   });
 
+  it('shows the stable tool name before the input label when the row uses a summary title', () => {
+    renderAssistant([
+      createToolComponent('bom_lifecycle_save_observation', {
+        title: 'Completed technical agreement extraction',
+        input: {
+          caseId: 'case-1',
+          changeSummary: 'Saved three observations',
+        },
+      }),
+    ]);
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /Completed technical agreement extraction/,
+      }),
+    );
+
+    expect(screen.getByText('Input').parentElement).toHaveTextContent(
+      'bom_lifecycle_save_observation·Input',
+    );
+  });
+
   it('preserves expanded tool row state when appending to the same group', () => {
     const firstTool = createToolComponent('read_file', {
       input: {

--- a/packages/chatkit-ui/src/components/thread/messages/tool-component-group.tsx
+++ b/packages/chatkit-ui/src/components/thread/messages/tool-component-group.tsx
@@ -897,7 +897,7 @@ function DefaultToolCallOutput({ data }: ComponentMessageDetailsRendererProps) {
 }
 
 function ToolCallDetails({ content }: { content: TMessageContentComponent }) {
-  const { t } = useChatkitTranslation();
+  const { i18n, t } = useChatkitTranslation();
   const data = getToolStepData(content);
   if (isSandboxShellStep(data)) {
     return (
@@ -923,6 +923,7 @@ function ToolCallDetails({ content }: { content: TMessageContentComponent }) {
   }
 
   const OutputRenderer = getToolCallOutputRenderer(data);
+  const toolName = resolveLocalizedText(data.tool, i18n.language);
   const hasInput = data.input !== undefined && data.input !== null;
   const hasOutput =
     data.error !== undefined ||
@@ -934,8 +935,18 @@ function ToolCallDetails({ content }: { content: TMessageContentComponent }) {
     <div className="ml-6 mt-1 max-h-60 overflow-auto rounded-md bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
       {hasInput && (
         <div className="space-y-1">
-          <div className="text-[11px] font-medium text-muted-foreground">
-            {t('message.toolGroup.inputTitle')}
+          <div className="flex min-w-0 items-baseline gap-1 text-[11px] font-medium text-muted-foreground">
+            {toolName ? (
+              <>
+                <span className="min-w-0 break-all font-mono text-foreground/80">
+                  {toolName}
+                </span>
+                <span aria-hidden="true">·</span>
+              </>
+            ) : null}
+            <span className="shrink-0">
+              {t('message.toolGroup.inputTitle')}
+            </span>
           </div>
           <ToolCallValueBlock value={data.input} />
         </div>

--- a/packages/chatkit-ui/src/components/thread/messages/tool-component-group.tsx
+++ b/packages/chatkit-ui/src/components/thread/messages/tool-component-group.tsx
@@ -29,9 +29,13 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 
-import { type LocalizedText, resolveLocalizedText } from '../../../i18n/localized-text';
+import {
+  type LocalizedText,
+  resolveLocalizedText,
+} from '../../../i18n/localized-text';
 import { useChatkitTranslation } from '../../../i18n/useChatkitTranslation';
 import { isThreadContextUsageRenderArtifact } from '../../../lib/thread-context-usage';
+import { parseToolOutputPresentation } from '../../../lib/tool-output-attachments';
 import { cn } from '../../../lib/utils';
 import {
   detectJsonValue,
@@ -54,6 +58,7 @@ import {
   isSandboxShellStep,
   SandboxShellToolCallCard,
 } from './sandbox-shell-tool-call';
+import { ToolOutputAttachments } from './tool-output-attachments';
 
 /** Partial step data: during streaming, fields arrive incrementally */
 export type PartialStepData = ComponentMessagePartialStepData;
@@ -151,7 +156,9 @@ function normalizeStepCategory(category: unknown): string {
   return category;
 }
 
-export function getToolStepData(content: TMessageContentComponent): PartialStepData {
+export function getToolStepData(
+  content: TMessageContentComponent,
+): PartialStepData {
   const data = (content.data ?? {}) as PartialStepData;
   const category = normalizeStepCategory(data.category);
 
@@ -247,7 +254,8 @@ function useToolStepDurationLabel(
   const explicitEndedAt = parseStepDate(data.end_date);
   const status = options?.status ?? data.status;
   const endedAt =
-    explicitEndedAt ?? (status !== 'running' ? (options?.fallbackEndedAt ?? null) : null);
+    explicitEndedAt ??
+    (status !== 'running' ? (options?.fallbackEndedAt ?? null) : null);
 
   React.useEffect(() => {
     if (status !== 'running' || createdAt === null || endedAt !== null) {
@@ -276,7 +284,9 @@ function isComponentContent(
   return content.type === 'component';
 }
 
-function isTextContent(content: TMessageContentComplex): content is TMessageContentText {
+function isTextContent(
+  content: TMessageContentComplex,
+): content is TMessageContentText {
   return content.type === 'text';
 }
 
@@ -326,11 +336,16 @@ function isSkippableToolGroupSeparator(
 
 function normalizeToolToken(value: unknown): string | null {
   if (typeof value !== 'string') return null;
-  const normalized = value.trim().toLowerCase().replace(/[\s-]+/g, '_');
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_');
   return normalized || null;
 }
 
-function classifyToolToken(value: LocalizedText | unknown): ToolGroupCategory | null {
+function classifyToolToken(
+  value: LocalizedText | unknown,
+): ToolGroupCategory | null {
   const normalized = normalizeToolToken(
     typeof value === 'string' ? value : resolveLocalizedText(value, 'en-US'),
   );
@@ -354,7 +369,8 @@ function classifyToolToken(value: LocalizedText | unknown): ToolGroupCategory | 
     return 'commands';
   }
   if (normalized.includes('list')) return 'lists';
-  if (normalized.includes('task') || normalized.includes('todo')) return 'tasks';
+  if (normalized.includes('task') || normalized.includes('todo'))
+    return 'tasks';
   if (normalized.includes('knowledge') || normalized.includes('retriever')) {
     return 'knowledges';
   }
@@ -362,7 +378,9 @@ function classifyToolToken(value: LocalizedText | unknown): ToolGroupCategory | 
   return null;
 }
 
-function getToolGroupCategory(content: TMessageContentComponent): ToolGroupCategory {
+function getToolGroupCategory(
+  content: TMessageContentComponent,
+): ToolGroupCategory {
   const data = getToolStepData(content);
   if (isSandboxShellStep(data)) return 'commands';
 
@@ -378,11 +396,14 @@ function getToolGroupCategory(content: TMessageContentComponent): ToolGroupCateg
 function getToolGroupCategoryCounts(
   items: TMessageContentComponent[],
 ): Partial<Record<ToolGroupCategory, number>> {
-  return items.reduce<Partial<Record<ToolGroupCategory, number>>>((counts, item) => {
-    const category = getToolGroupCategory(item);
-    counts[category] = (counts[category] ?? 0) + 1;
-    return counts;
-  }, {});
+  return items.reduce<Partial<Record<ToolGroupCategory, number>>>(
+    (counts, item) => {
+      const category = getToolGroupCategory(item);
+      counts[category] = (counts[category] ?? 0) + 1;
+      return counts;
+    },
+    {},
+  );
 }
 
 export function getToolActivityLabel(
@@ -471,7 +492,8 @@ function getToolCallOutputRenderer(
   data: PartialStepData,
 ): ComponentMessageDetailsRenderer {
   const keys = [data.tool, data.type].filter(
-    (value): value is string => typeof value === 'string' && Boolean(value.trim()),
+    (value): value is string =>
+      typeof value === 'string' && Boolean(value.trim()),
   );
 
   for (const key of keys) {
@@ -516,7 +538,8 @@ function createToolsetIconUrl(
 }
 
 function createToolsetAvatarUrl(toolsetId: unknown, apiUrl?: string) {
-  const normalizedToolsetId = typeof toolsetId === 'string' ? toolsetId.trim() : '';
+  const normalizedToolsetId =
+    typeof toolsetId === 'string' ? toolsetId.trim() : '';
   if (!normalizedToolsetId) return null;
 
   const path = `/api/xpert-toolset/${encodeURIComponent(normalizedToolsetId)}/avatar`;
@@ -537,7 +560,11 @@ function shouldUseToolsetAvatar(toolset: unknown) {
   return normalized === 'mcp' || normalized === 'openapi';
 }
 
-function useToolsetAvatar(toolsetId: unknown, enabled: boolean, apiUrl?: string) {
+function useToolsetAvatar(
+  toolsetId: unknown,
+  enabled: boolean,
+  apiUrl?: string,
+) {
   const avatarUrl = enabled ? createToolsetAvatarUrl(toolsetId, apiUrl) : null;
   const [avatar, setAvatar] = React.useState<unknown>(null);
 
@@ -610,7 +637,9 @@ function ToolAvatarIcon({
           className,
         )}
         data-slot="tool-step-icon"
-        style={avatar.background ? { background: avatar.background } : undefined}
+        style={
+          avatar.background ? { background: avatar.background } : undefined
+        }
         title={label}
       >
         {emoji}
@@ -684,11 +713,7 @@ function ToolStepIcon({
   apiUrl?: string;
 }) {
   const usesToolsetAvatar = shouldUseToolsetAvatar(data.toolset);
-  const avatar = useToolsetAvatar(
-    data.toolset_id,
-    usesToolsetAvatar,
-    apiUrl,
-  );
+  const avatar = useToolsetAvatar(data.toolset_id, usesToolsetAvatar, apiUrl);
   const iconUrl = createToolsetIconUrl(data.toolset, organizationId, apiUrl);
   const [failedIconUrl, setFailedIconUrl] = React.useState<string | null>(null);
 
@@ -844,7 +869,8 @@ function ToolCallValueBlock({
     <Tabs defaultValue="tree" className="min-w-0">
       <div className="mb-2 flex min-w-0 items-center justify-between gap-2">
         <span className="min-w-0 truncate text-[11px] text-muted-foreground">
-          {t('message.toolGroup.jsonTitle')} · {getJsonValueSummary(detected.value)}
+          {t('message.toolGroup.jsonTitle')} ·{' '}
+          {getJsonValueSummary(detected.value)}
         </span>
         <div className="flex shrink-0 items-center gap-1">
           <ToolCallCopyButton value={detected.raw} />
@@ -868,9 +894,13 @@ function ToolCallValueBlock({
   );
 }
 
-function DefaultToolCallOutput({ data }: ComponentMessageDetailsRendererProps) {
+function DefaultToolCallOutput({
+  content,
+  data,
+}: ComponentMessageDetailsRendererProps) {
   const { t } = useChatkitTranslation();
-  const output = data.output ?? null;
+  const presentation = parseToolOutputPresentation(data.artifact);
+  const output = data.output ?? (presentation ? null : data.artifact) ?? null;
   const error = data.error ?? null;
 
   if (error) {
@@ -884,14 +914,21 @@ function DefaultToolCallOutput({ data }: ComponentMessageDetailsRendererProps) {
     );
   }
 
-  if (output === null) return null;
+  if (output === null && !presentation) return null;
 
   return (
-    <div className="space-y-1">
+    <div className="space-y-2">
       <div className="text-[11px] font-medium text-muted-foreground">
         {t('message.toolGroup.outputTitle')}
       </div>
-      <ToolCallValueBlock value={output} />
+      {presentation ? (
+        <ToolOutputAttachments
+          presentation={presentation}
+          toolCallId={content.id}
+          executionId={content.executionId}
+        />
+      ) : null}
+      {output !== null ? <ToolCallValueBlock value={output} /> : null}
     </div>
   );
 }
@@ -927,7 +964,8 @@ function ToolCallDetails({ content }: { content: TMessageContentComponent }) {
   const hasInput = data.input !== undefined && data.input !== null;
   const hasOutput =
     data.error !== undefined ||
-    data.output !== undefined;
+    data.output !== undefined ||
+    data.artifact !== undefined;
 
   if (!hasInput && !hasOutput) return null;
 
@@ -1003,6 +1041,7 @@ function ToolCallRowContent({
     data.input !== undefined ||
     data.error !== undefined ||
     data.output !== undefined ||
+    data.artifact !== undefined ||
     hasCustomDetails;
   const fallbackEndedAt = useFrozenTimestamp(
     data.status === 'running' && status === 'fail',
@@ -1014,10 +1053,13 @@ function ToolCallRowContent({
   const [isExpanded, setIsExpanded] = React.useState(false);
 
   React.useEffect(() => {
-    if (status === 'running' && data.output !== undefined) {
+    if (
+      status === 'running' &&
+      (data.output !== undefined || data.artifact !== undefined)
+    ) {
       setIsExpanded(true);
     }
-  }, [data.output, status]);
+  }, [data.artifact, data.output, status]);
 
   return (
     <li className="ck-tool-call-row-enter min-w-0">
@@ -1135,12 +1177,7 @@ export function ToolComponentGroup({
         onClick={() => setIsExpanded((prev) => !prev)}
       >
         <div className="flex min-w-0 items-center gap-2 text-sm font-medium text-muted-foreground">
-          <StatusIcon
-            className={cn(
-              'h-4 w-4 shrink-0',
-              config.iconClass,
-            )}
-          />
+          <StatusIcon className={cn('h-4 w-4 shrink-0', config.iconClass)} />
           <span className="truncate">{summary}</span>
         </div>
         <ChevronRight

--- a/packages/chatkit-ui/src/components/thread/messages/tool-output-attachments.test.tsx
+++ b/packages/chatkit-ui/src/components/thread/messages/tool-output-attachments.test.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+
+import type { ToolOutputPresentation } from '@xpert-ai/chatkit-types';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ParentMessengerContext } from '../../../providers/ParentMessenger';
+import { ToolOutputAttachments } from './tool-output-attachments';
+
+const presentation: ToolOutputPresentation = {
+  type: 'xpert.tool-output',
+  version: 1,
+  attachments: [
+    {
+      type: 'image',
+      artifactId: 'artifact-1',
+      artifactVersionId: 'version-1',
+      sha256: 'a'.repeat(64),
+      mimeType: 'image/png',
+      width: 1280,
+      height: 720,
+      title: 'Flange loading sketch',
+      alt: 'Sketch showing flange loading dimensions',
+      source: 'knowledge-document',
+      modelDetail: 'high',
+      anchors: {
+        page: 75,
+        visualAssetId: 'visual-asset-1',
+      },
+    },
+  ],
+};
+
+type ParentMessengerValue = NonNullable<
+  React.ComponentProps<typeof ParentMessengerContext.Provider>['value']
+>;
+
+function parentMessengerValue(
+  sendCommand: ParentMessengerValue['sendCommand'],
+): ParentMessengerValue {
+  const unregister = () => () => undefined;
+  return {
+    isParentAvailable: true,
+    sendCommand,
+    sendEvent: vi.fn(),
+    registerOnSetOptions: unregister,
+    registerOnSetPetEnabled: unregister,
+    registerOnSetComposerValue: unregister,
+    registerOnSetRuntimeCapabilities: unregister,
+    registerOnFocusComposer: unregister,
+  };
+}
+
+describe('ToolOutputAttachments', () => {
+  it('resolves a private preview through the host and opens the image dialog', async () => {
+    const sendCommand = vi.fn().mockResolvedValue({
+      previewUrl: 'https://assets.example/flange.png?token=short-lived',
+    });
+
+    render(
+      <ParentMessengerContext.Provider
+        value={parentMessengerValue(sendCommand)}
+      >
+        <ToolOutputAttachments
+          presentation={presentation}
+          toolCallId="tool-call-1"
+          executionId="execution-1"
+        />
+      </ParentMessengerContext.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(sendCommand).toHaveBeenCalledWith(
+        'onToolOutputAttachmentPreview',
+        {
+          attachment: presentation.attachments[0],
+          toolCallId: 'tool-call-1',
+          executionId: 'execution-1',
+        },
+      );
+    });
+
+    const openButton = await screen.findByRole('button', {
+      name: /Open Flange loading sketch/i,
+    });
+    expect(
+      screen.getByAltText('Sketch showing flange loading dimensions'),
+    ).toHaveAttribute(
+      'src',
+      'https://assets.example/flange.png?token=short-lived',
+    );
+
+    fireEvent.click(openButton);
+
+    expect(
+      screen.getByRole('dialog', { name: 'Flange loading sketch' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Close image preview' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a recoverable state when the trusted host rejects preview access', async () => {
+    const sendCommand = vi.fn().mockRejectedValue(new Error('forbidden'));
+
+    render(
+      <ParentMessengerContext.Provider
+        value={parentMessengerValue(sendCommand)}
+      >
+        <ToolOutputAttachments presentation={presentation} />
+      </ParentMessengerContext.Provider>,
+    );
+
+    expect(await screen.findByText('Preview unavailable')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(sendCommand).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not loop preview resolution when a resolved image fails to load', async () => {
+    const sendCommand = vi.fn().mockResolvedValue({
+      previewUrl: 'https://assets.example/broken.png?token=short-lived',
+    });
+
+    render(
+      <ParentMessengerContext.Provider
+        value={parentMessengerValue(sendCommand)}
+      >
+        <ToolOutputAttachments presentation={presentation} />
+      </ParentMessengerContext.Provider>,
+    );
+
+    const image = await screen.findByAltText(
+      'Sketch showing flange loading dimensions',
+    );
+    fireEvent.error(image);
+
+    expect(await screen.findByText('Preview unavailable')).toBeInTheDocument();
+    expect(sendCommand).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/chatkit-ui/src/components/thread/messages/tool-output-attachments.tsx
+++ b/packages/chatkit-ui/src/components/thread/messages/tool-output-attachments.tsx
@@ -1,0 +1,258 @@
+import * as React from 'react';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import type {
+  ToolOutputAttachmentPreviewRequest,
+  ToolOutputImageAttachment,
+  ToolOutputPresentation,
+} from '@xpert-ai/chatkit-types';
+import { ImageIcon, Loader2, RefreshCw, X } from 'lucide-react';
+
+import { useChatkitTranslation } from '../../../i18n/useChatkitTranslation';
+import {
+  parseToolOutputAttachmentPreview,
+  toolOutputAttachmentKey,
+} from '../../../lib/tool-output-attachments';
+import { cn } from '../../../lib/utils';
+import { ParentMessengerContext } from '../../../providers/ParentMessenger';
+
+type PreviewState =
+  | { status: 'loading' }
+  | { status: 'success'; previewUrl: string }
+  | { status: 'error' };
+
+function useToolOutputAttachmentPreview(
+  request: ToolOutputAttachmentPreviewRequest,
+) {
+  const parentMessenger = React.useContext(ParentMessengerContext);
+  const [attempt, setAttempt] = React.useState(0);
+  const [state, setState] = React.useState<PreviewState>({
+    status: 'loading',
+  });
+  const attachmentKey = toolOutputAttachmentKey(request.attachment);
+
+  React.useEffect(() => {
+    if (!parentMessenger?.isParentAvailable) {
+      setState({ status: 'error' });
+      return;
+    }
+
+    let cancelled = false;
+    let refreshTimer: number | null = null;
+    setState({ status: 'loading' });
+
+    void parentMessenger
+      .sendCommand('onToolOutputAttachmentPreview', request)
+      .then((response) => {
+        if (cancelled) return;
+        const preview = parseToolOutputAttachmentPreview(response);
+        if (!preview) {
+          setState({ status: 'error' });
+          return;
+        }
+
+        if (preview.expiresAt) {
+          const remainingLifetime = Date.parse(preview.expiresAt) - Date.now();
+          if (remainingLifetime <= 0) {
+            setState({ status: 'error' });
+            return;
+          }
+          refreshTimer = window.setTimeout(
+            () => setAttempt((current) => current + 1),
+            Math.max(1_000, Math.floor(remainingLifetime * 0.8)),
+          );
+        }
+
+        setState({ status: 'success', previewUrl: preview.previewUrl });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ status: 'error' });
+      });
+
+    return () => {
+      cancelled = true;
+      if (refreshTimer !== null) window.clearTimeout(refreshTimer);
+    };
+  }, [attachmentKey, attempt, parentMessenger, request]);
+
+  return {
+    state,
+    fail: () => setState({ status: 'error' }),
+    retry: () => setAttempt((current) => current + 1),
+  };
+}
+
+function attachmentTitle(
+  attachment: ToolOutputImageAttachment,
+  fallback: string,
+) {
+  return (
+    attachment.title ??
+    attachment.alt ??
+    (attachment.anchors?.page
+      ? `${fallback} · ${attachment.anchors.page}`
+      : fallback)
+  );
+}
+
+function ToolOutputImageAttachmentCard({
+  attachment,
+  index,
+  toolCallId,
+  executionId,
+}: {
+  attachment: ToolOutputImageAttachment;
+  index: number;
+  toolCallId?: string;
+  executionId?: string;
+}) {
+  const { t } = useChatkitTranslation();
+  const request = React.useMemo<ToolOutputAttachmentPreviewRequest>(
+    () => ({ attachment, toolCallId, executionId }),
+    [attachment, executionId, toolCallId],
+  );
+  const { state, fail, retry } = useToolOutputAttachmentPreview(request);
+  const fallbackTitle = t('message.toolGroup.attachments.imageTitle', {
+    index: index + 1,
+  });
+  const title = attachmentTitle(attachment, fallbackTitle);
+  const dimensions =
+    attachment.width && attachment.height
+      ? `${attachment.width} × ${attachment.height}`
+      : null;
+  const sourceLabel = t(
+    `message.toolGroup.attachments.sources.${attachment.source}`,
+  );
+  const description = [
+    sourceLabel,
+    dimensions,
+    t('message.toolGroup.attachments.modelDetail', {
+      detail: attachment.modelDetail,
+    }),
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  if (state.status === 'loading') {
+    return (
+      <div
+        className="flex aspect-video min-w-0 items-center justify-center rounded-lg border border-border bg-background"
+        aria-label={t('message.toolGroup.attachments.loading', { title })}
+      >
+        <Loader2
+          className="h-5 w-5 animate-spin text-muted-foreground"
+          aria-hidden="true"
+        />
+      </div>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <div className="flex aspect-video min-w-0 flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border bg-background px-3 text-center">
+        <ImageIcon
+          className="h-5 w-5 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <span className="line-clamp-2 text-[11px] text-muted-foreground">
+          {t('message.toolGroup.attachments.unavailable')}
+        </span>
+        <button
+          type="button"
+          className="inline-flex h-7 items-center gap-1 rounded-md px-2 text-[11px] font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          onClick={retry}
+        >
+          <RefreshCw className="h-3 w-3" aria-hidden="true" />
+          {t('message.toolGroup.attachments.retry')}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger asChild>
+        <button
+          type="button"
+          className="group relative aspect-video min-w-0 overflow-hidden rounded-lg border border-border bg-background text-left shadow-sm transition hover:border-ring/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          aria-label={t('message.toolGroup.attachments.open', { title })}
+        >
+          <img
+            className="h-full w-full object-cover transition-transform group-hover:scale-[1.02]"
+            src={state.previewUrl}
+            alt={attachment.alt ?? title}
+            loading="lazy"
+            referrerPolicy="no-referrer"
+            onError={fail}
+          />
+          <span className="absolute inset-x-0 bottom-0 bg-black/65 px-2 py-1.5 text-[11px] font-medium leading-4 text-white">
+            <span className="line-clamp-1">{title}</span>
+            <span className="block truncate text-white/70">{description}</span>
+          </span>
+        </button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[80] bg-black/80 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content
+          className={cn(
+            'fixed left-1/2 top-1/2 z-[81] flex max-h-[92vh] w-[min(92vw,1200px)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl',
+            'focus:outline-none data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+          )}
+        >
+          <div className="flex min-w-0 items-start justify-between gap-3 border-b border-border px-4 py-3">
+            <div className="min-w-0">
+              <Dialog.Title className="truncate text-sm font-semibold text-foreground">
+                {title}
+              </Dialog.Title>
+              <Dialog.Description className="mt-0.5 text-xs text-muted-foreground">
+                {description}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              aria-label={t('message.toolGroup.attachments.close')}
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </Dialog.Close>
+          </div>
+          <div className="min-h-0 flex-1 overflow-auto bg-black/95 p-4">
+            <img
+              className="mx-auto h-auto max-h-[calc(92vh-6rem)] max-w-full object-contain"
+              src={state.previewUrl}
+              alt={attachment.alt ?? title}
+              referrerPolicy="no-referrer"
+              onError={fail}
+            />
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+export function ToolOutputAttachments({
+  presentation,
+  toolCallId,
+  executionId,
+}: {
+  presentation: ToolOutputPresentation;
+  toolCallId?: string;
+  executionId?: string;
+}) {
+  return (
+    <div
+      className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3"
+      data-testid="tool-output-attachments"
+    >
+      {presentation.attachments.map((attachment, index) => (
+        <ToolOutputImageAttachmentCard
+          key={toolOutputAttachmentKey(attachment)}
+          attachment={attachment}
+          index={index}
+          toolCallId={toolCallId}
+          executionId={executionId}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/chatkit-ui/src/i18n/locales/en-US.json
+++ b/packages/chatkit-ui/src/i18n/locales/en-US.json
@@ -425,6 +425,19 @@
       "copy": "Copy",
       "copied": "Copied",
       "separator": ", ",
+      "attachments": {
+        "imageTitle": "Image {{index}}",
+        "loading": "Loading {{title}}",
+        "unavailable": "Preview unavailable",
+        "retry": "Retry",
+        "open": "Open {{title}}",
+        "close": "Close image preview",
+        "modelDetail": "Model detail: {{detail}}",
+        "sources": {
+          "knowledge-document": "Knowledge document",
+          "sandbox": "Sandbox"
+        }
+      },
       "shell": {
         "success": "Success",
         "running": "Running",

--- a/packages/chatkit-ui/src/i18n/locales/zh-CN.json
+++ b/packages/chatkit-ui/src/i18n/locales/zh-CN.json
@@ -425,6 +425,19 @@
       "copy": "复制",
       "copied": "已复制",
       "separator": "，",
+      "attachments": {
+        "imageTitle": "图片 {{index}}",
+        "loading": "正在加载{{title}}",
+        "unavailable": "图片预览不可用",
+        "retry": "重试",
+        "open": "查看{{title}}",
+        "close": "关闭图片预览",
+        "modelDetail": "模型清晰度：{{detail}}",
+        "sources": {
+          "knowledge-document": "知识文档",
+          "sandbox": "沙箱"
+        }
+      },
       "shell": {
         "success": "成功",
         "running": "运行中",

--- a/packages/chatkit-ui/src/lib/thread-runs.test.ts
+++ b/packages/chatkit-ui/src/lib/thread-runs.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { Run } from '@xpert-ai/xpert-sdk';
+import {
+  resolveActiveThreadRunId,
+  waitForActiveThreadRunId,
+} from './thread-runs';
+
+function createRun(
+  runId: string,
+  status: Run['status'],
+  updatedAt: string,
+): Run {
+  return {
+    run_id: runId,
+    thread_id: 'thread-1',
+    assistant_id: 'assistant-1',
+    created_at: updatedAt,
+    updated_at: updatedAt,
+    status,
+    metadata: {},
+    multitask_strategy: null,
+  };
+}
+
+describe('resolveActiveThreadRunId', () => {
+  it('resolves a running execution before an assistant message exists', () => {
+    expect(
+      resolveActiveThreadRunId([
+        createRun('run-finished', 'success', '2026-08-13T10:00:00Z'),
+        createRun('run-active', 'running', '2026-08-13T10:01:00Z'),
+      ]),
+    ).toBe('run-active');
+  });
+
+  it('chooses the newest pending or running execution', () => {
+    expect(
+      resolveActiveThreadRunId([
+        createRun('run-older', 'running', '2026-08-13T10:00:00Z'),
+        createRun('run-newer', 'pending', '2026-08-13T10:02:00Z'),
+      ]),
+    ).toBe('run-newer');
+  });
+
+  it('ignores terminal executions', () => {
+    expect(
+      resolveActiveThreadRunId([
+        createRun('run-success', 'success', '2026-08-13T10:00:00Z'),
+        createRun('run-error', 'error', '2026-08-13T10:01:00Z'),
+      ]),
+    ).toBeNull();
+  });
+
+  it('retries while a newly-created execution is not visible yet', async () => {
+    let attempt = 0;
+
+    const runId = await waitForActiveThreadRunId(
+      async () => {
+        attempt += 1;
+        return attempt < 3
+          ? []
+          : [createRun('run-late', 'running', '2026-08-13T10:02:00Z')];
+      },
+      { attempts: 3, intervalMs: 0 },
+    );
+
+    expect(runId).toBe('run-late');
+    expect(attempt).toBe(3);
+  });
+
+  it('stops retrying after the user switches to another thread', async () => {
+    let active = true;
+    let attempt = 0;
+
+    const runId = await waitForActiveThreadRunId(
+      async () => {
+        attempt += 1;
+        active = false;
+        return [];
+      },
+      { attempts: 3, intervalMs: 0, shouldContinue: () => active },
+    );
+
+    expect(runId).toBeNull();
+    expect(attempt).toBe(1);
+  });
+});

--- a/packages/chatkit-ui/src/lib/thread-runs.ts
+++ b/packages/chatkit-ui/src/lib/thread-runs.ts
@@ -1,0 +1,50 @@
+import type { Run } from '@xpert-ai/xpert-sdk';
+
+const ACTIVE_RUN_STATUSES = new Set<Run['status']>(['pending', 'running']);
+
+function runTimestamp(run: Run): number {
+  const timestamp = Date.parse(run.updated_at || run.created_at);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+/**
+ * Resolve the newest active root run returned by the thread runs endpoint.
+ *
+ * A newly-created run can exist before the first assistant message is
+ * persisted. Thread loading must therefore use the run ledger as the source
+ * of truth instead of waiting for a message.executionId to appear.
+ */
+export function resolveActiveThreadRunId(runs: readonly Run[]): string | null {
+  const activeRun = runs
+    .filter(
+      (run) =>
+        ACTIVE_RUN_STATUSES.has(run.status) && Boolean(run.run_id?.trim()),
+    )
+    .sort((left, right) => runTimestamp(right) - runTimestamp(left))[0];
+
+  return activeRun?.run_id.trim() || null;
+}
+
+export async function waitForActiveThreadRunId(
+  loadRuns: () => Promise<readonly Run[]>,
+  options: {
+    attempts?: number;
+    intervalMs?: number;
+    shouldContinue?: () => boolean;
+  } = {},
+): Promise<string | null> {
+  const attempts = Math.max(1, options.attempts ?? 20);
+  const intervalMs = Math.max(0, options.intervalMs ?? 250);
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (options.shouldContinue && !options.shouldContinue()) return null;
+
+    const runId = resolveActiveThreadRunId(await loadRuns());
+    if (runId) return runId;
+    if (attempt === attempts - 1) break;
+
+    await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  return null;
+}

--- a/packages/chatkit-ui/src/lib/tool-output-attachments.test.ts
+++ b/packages/chatkit-ui/src/lib/tool-output-attachments.test.ts
@@ -1,0 +1,95 @@
+import {
+  parseToolOutputAttachmentPreview,
+  parseToolOutputPresentation,
+} from './tool-output-attachments';
+import { describe, expect, it } from 'vitest';
+
+const sha256 = 'a'.repeat(64);
+
+describe('tool output attachments', () => {
+  it('accepts immutable image artifact descriptors without persisted URLs', () => {
+    expect(
+      parseToolOutputPresentation({
+        type: 'xpert.tool-output',
+        version: 1,
+        attachments: [
+          {
+            type: 'image',
+            artifactId: 'artifact-1',
+            artifactVersionId: 'version-1',
+            sha256,
+            mimeType: 'image/png',
+            width: 1280,
+            height: 720,
+            title: 'Drawing on page 75',
+            source: 'knowledge-document',
+            modelDetail: 'high',
+            anchors: {
+              knowledgeDocumentId: 'document-1',
+              page: 75,
+              visualAssetId: 'asset-1',
+            },
+          },
+        ],
+      }),
+    ).toMatchObject({
+      type: 'xpert.tool-output',
+      attachments: [{ artifactVersionId: 'version-1', sha256 }],
+    });
+  });
+
+  it('rejects embedded URLs, base64 data, SVG, and invalid hashes', () => {
+    const baseAttachment = {
+      type: 'image',
+      artifactId: 'artifact-1',
+      artifactVersionId: 'version-1',
+      sha256,
+      mimeType: 'image/png',
+      source: 'sandbox',
+      modelDetail: 'low',
+    };
+
+    expect(
+      parseToolOutputPresentation({
+        type: 'xpert.tool-output',
+        version: 1,
+        attachments: [
+          { ...baseAttachment, previewUrl: 'data:image/png;base64,AAAA' },
+        ],
+      }),
+    ).toBeNull();
+    expect(
+      parseToolOutputPresentation({
+        type: 'xpert.tool-output',
+        version: 1,
+        attachments: [{ ...baseAttachment, mimeType: 'image/svg+xml' }],
+      }),
+    ).toBeNull();
+    expect(
+      parseToolOutputPresentation({
+        type: 'xpert.tool-output',
+        version: 1,
+        attachments: [{ ...baseAttachment, sha256: 'not-a-hash' }],
+      }),
+    ).toBeNull();
+  });
+
+  it('only accepts host-resolved HTTP(S) preview URLs', () => {
+    expect(
+      parseToolOutputAttachmentPreview({
+        previewUrl: 'https://assets.example/tool-image.png?token=short-lived',
+        expiresAt: '2026-08-17T10:00:00.000Z',
+      }),
+    ).not.toBeNull();
+    expect(
+      parseToolOutputAttachmentPreview({
+        previewUrl: 'data:image/png;base64,AAAA',
+      }),
+    ).toBeNull();
+    expect(
+      parseToolOutputAttachmentPreview({
+        previewUrl: 'javascript:alert(1)',
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/chatkit-ui/src/lib/tool-output-attachments.ts
+++ b/packages/chatkit-ui/src/lib/tool-output-attachments.ts
@@ -1,0 +1,89 @@
+import {
+  TOOL_OUTPUT_PRESENTATION_TYPE,
+  TOOL_OUTPUT_PRESENTATION_VERSION,
+  type ToolOutputAttachmentPreview,
+  type ToolOutputImageAttachment,
+  type ToolOutputPresentation,
+} from '@xpert-ai/chatkit-types';
+import { z } from 'zod';
+
+const boundedId = z.string().trim().min(1).max(256);
+const boundedLabel = z.string().trim().min(1).max(500);
+
+const toolOutputImageAnchorsSchema = z
+  .object({
+    knowledgeDocumentId: boundedId.optional(),
+    page: z.number().int().positive().max(1_000_000).optional(),
+    chunkId: boundedId.optional(),
+    sourceBlockIds: z.array(boundedId).max(100).optional(),
+    visualAssetId: boundedId.optional(),
+  })
+  .strict();
+
+const toolOutputImageAttachmentSchema = z
+  .object({
+    type: z.literal('image'),
+    artifactId: boundedId,
+    artifactVersionId: boundedId,
+    sha256: z.string().regex(/^[a-f0-9]{64}$/i),
+    mimeType: z.enum(['image/png', 'image/jpeg', 'image/webp']),
+    width: z.number().int().positive().max(100_000).optional(),
+    height: z.number().int().positive().max(100_000).optional(),
+    title: boundedLabel.optional(),
+    alt: boundedLabel.optional(),
+    source: z.enum(['knowledge-document', 'sandbox']),
+    modelDetail: z.enum(['auto', 'low', 'high']),
+    anchors: toolOutputImageAnchorsSchema.optional(),
+  })
+  .strict();
+
+const toolOutputPresentationSchema = z
+  .object({
+    type: z.literal(TOOL_OUTPUT_PRESENTATION_TYPE),
+    version: z.literal(TOOL_OUTPUT_PRESENTATION_VERSION),
+    attachments: z.array(toolOutputImageAttachmentSchema).min(1).max(20),
+  })
+  .strict();
+
+const toolOutputAttachmentPreviewSchema = z
+  .object({
+    previewUrl: z.string().url(),
+    expiresAt: z.string().optional(),
+  })
+  .strict()
+  .superRefine((preview, context) => {
+    const protocol = new URL(preview.previewUrl).protocol;
+    if (protocol !== 'https:' && protocol !== 'http:') {
+      context.addIssue({
+        code: 'custom',
+        message: 'Tool-output previews must use an HTTP(S) URL.',
+        path: ['previewUrl'],
+      });
+    }
+
+    if (preview.expiresAt && Number.isNaN(Date.parse(preview.expiresAt))) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Tool-output preview expiry must be an ISO date string.',
+        path: ['expiresAt'],
+      });
+    }
+  });
+
+export function parseToolOutputPresentation(
+  value: unknown,
+): ToolOutputPresentation | null {
+  const result = toolOutputPresentationSchema.safeParse(value);
+  return result.success ? result.data : null;
+}
+
+export function parseToolOutputAttachmentPreview(
+  value: unknown,
+): ToolOutputAttachmentPreview | null {
+  const result = toolOutputAttachmentPreviewSchema.safeParse(value);
+  return result.success ? result.data : null;
+}
+
+export function toolOutputAttachmentKey(attachment: ToolOutputImageAttachment) {
+  return `${attachment.artifactId}:${attachment.artifactVersionId}:${attachment.sha256}`;
+}

--- a/packages/chatkit-ui/src/providers/ParentMessenger.tsx
+++ b/packages/chatkit-ui/src/providers/ParentMessenger.tsx
@@ -13,6 +13,7 @@ import {
   type ChatKitReferenceCompositionMode,
   type FollowUpBehavior,
   type SendUserMessageParams,
+  type ToolOutputAttachmentPreviewRequest,
 } from '@xpert-ai/chatkit-types';
 import type { Capability } from '@xpert-ai/chatkit-web-shared';
 import type { Message } from '@xpert-ai/xpert-sdk';
@@ -36,6 +37,7 @@ type CommandMessageMap = {
   onFocusComposer: null;
   onSetThreadId: { threadId: string | null };
   onClientToolCall: unknown;
+  onToolOutputAttachmentPreview: ToolOutputAttachmentPreviewRequest;
   onWorkbenchClientCommand: {
     commandKey: string;
     payload?: unknown;

--- a/packages/chatkit-ui/src/providers/Stream.tsx
+++ b/packages/chatkit-ui/src/providers/Stream.tsx
@@ -71,6 +71,7 @@ import {
 } from '../lib/client-secret';
 import { createMissingApiConfigurationError } from '../lib/api-config';
 import { normalizeRequestContextAndConfig } from '../lib/request-options';
+import { waitForActiveThreadRunId } from '../lib/thread-runs';
 import type { RuntimeCapabilitiesSelection } from '../lib/runtime-capabilities';
 import { useParentMessenger } from '../hooks/useParentMessenger';
 import type { ParentMessenger } from './ParentMessenger';
@@ -3218,20 +3219,40 @@ const StreamSession = ({
         conversationDetail.status ?? conversation.status ?? '',
       ).toLowerCase();
       if (status === 'interrupted') return;
-      const shouldJoinStream =
+      const conversationMayBeRunning =
         !status || status === 'running' || status === 'busy';
-      if (!shouldJoinStream) return;
 
-      const lastAiMessageResult = await client.conversations.searchMessages(
-        conversation.id,
-        {
-          where: { role: 'ai' },
-          order: { createdAt: 'DESC' },
-          limit: 1,
-        },
-      );
-      const runId = lastAiMessageResult.items?.[0]?.executionId ?? null;
+      let runId: string | null = null;
+      let runLookupFailed = false;
+      try {
+        runId = await waitForActiveThreadRunId(
+          () => client.runs.list(threadId, { limit: 100 }),
+          {
+            attempts: conversationMayBeRunning ? 20 : 1,
+            shouldContinue: () => activeThreadIdRef.current === threadId,
+          },
+        );
+      } catch (runsError) {
+        console.warn(
+          '[chatkit-ui] Failed to resolve the active execution from thread runs',
+          runsError,
+        );
+        runLookupFailed = true;
+      }
+
+      // Compatibility fallback for completed or legacy conversations whose
+      // execution can only be recovered from a persisted assistant message.
+      if (!runId && runLookupFailed && conversationMayBeRunning) {
+        const lastAiMessageResult =
+          await client.conversations.searchMessages(conversation.id, {
+            where: { role: 'ai' },
+            order: { createdAt: 'DESC' },
+            limit: 1,
+          });
+        runId = lastAiMessageResult.items?.[0]?.executionId ?? null;
+      }
       if (!runId) return;
+      if (activeThreadIdRef.current !== threadId) return;
       lastExecutionIdRef.current = runId;
 
       await runStream(threadId, null, { joinExistingThread: true }, runId);

--- a/packages/chatkit/README.md
+++ b/packages/chatkit/README.md
@@ -7,3 +7,57 @@ This package is the type-definition library for ChatKit, providing unified, reus
 - Exposes the interface signatures and event types of `XpertAIChatKit`, ensuring consistency between integrators and internal implementation.
 - Aggregates core chat-related types (such as `ChatKitOptions`, messages, attachments, widgets, interrupts) for reuse by the UI package and business side.
 - Serves as a standalone types package so that the ChatKit Web Component and the XpertAI platform can obtain type hints and validation without bringing in implementation code.
+
+## Tool output image attachments
+
+Tools that prepare images for a model vision step can expose the same immutable
+images in the tool-call output with a `ToolOutputPresentation` artifact. Persist
+only Artifact identity and display metadata in message history—never a signed
+URL, storage path, or base64 payload.
+
+```ts
+const artifact: ToolOutputPresentation = {
+  type: 'xpert.tool-output',
+  version: 1,
+  attachments: [
+    {
+      type: 'image',
+      artifactId: 'artifact-id',
+      artifactVersionId: 'immutable-version-id',
+      sha256: 'a'.repeat(64),
+      mimeType: 'image/png',
+      title: 'Picture 1 on page 75',
+      source: 'knowledge-document',
+      modelDetail: 'high',
+      anchors: { knowledgeDocumentId: 'document-id', page: 75 },
+    },
+  ],
+};
+```
+
+The embedding host authorizes preview access and resolves a short-lived URL at
+render time:
+
+```ts
+const options: Partial<ChatKitOptions> = {
+  toolOutputAttachments: {
+    onRequestPreview: async ({ attachment }) => {
+      const preview = await authorizedArtifactPreviewResolver({
+        artifactId: attachment.artifactId,
+        artifactVersionId: attachment.artifactVersionId,
+        sha256: attachment.sha256,
+      });
+
+      return {
+        previewUrl: preview.url,
+        expiresAt: preview.expiresAt,
+      };
+    },
+  },
+};
+```
+
+The resolver must authorize the current user and requested Artifact version.
+ChatKit validates the descriptor, accepts only PNG/JPEG/WebP previews over
+HTTP(S), does not persist the resolved URL, and resolves it again after expiry
+or page reload.

--- a/packages/chatkit/src/index.ts
+++ b/packages/chatkit/src/index.ts
@@ -6,5 +6,6 @@ export * from './message.js';
 export * from './options.js';
 export * from './pet.js';
 export * from './task-summary.js';
+export * from './tool-output.js';
 export * from './chatkit.js';
 export * from './commands.js';

--- a/packages/chatkit/src/message.ts
+++ b/packages/chatkit/src/message.ts
@@ -4,6 +4,7 @@ import type { FollowUpBehavior } from './options';
 import type { ChatKitCommandSource } from './commands';
 import type { LocalizedText } from './localized-text';
 import type { TChatTaskSummaryContribution } from './task-summary';
+import type { ImageDetail, ToolMessageArtifact } from './tool-output';
 import {
   CHAT_EVENT_TYPE_FOLLOW_UP_CONSUMED,
   ChatMessageEventTypeEnum,
@@ -29,7 +30,7 @@ export type TChatMessageStep<T = any> = TMessageComponent<
   TMessageComponentStep<T>
 >;
 
-export type ImageDetail = 'auto' | 'low' | 'high';
+export type { ImageDetail } from './tool-output';
 export type MessageContentText = {
   type: 'text';
   text: string;
@@ -304,7 +305,7 @@ export type TMessageComponentStep<T = unknown> = {
   data?: T;
   input?: any;
   output?: unknown;
-  artifact?: any;
+  artifact?: ToolMessageArtifact;
   taskSummary?: TChatTaskSummaryContribution;
 };
 

--- a/packages/chatkit/src/options.ts
+++ b/packages/chatkit/src/options.ts
@@ -5,6 +5,10 @@ import type {
   ThreadGoal,
   ThreadGoalStatus,
 } from './message';
+import type {
+  ToolOutputAttachmentPreview,
+  ToolOutputAttachmentPreviewRequest,
+} from './tool-output';
 import type * as Widgets from './widgets';
 
 export * from './widgets';
@@ -609,6 +613,19 @@ export type ChatKitOptions = {
     id?: string;
     tool_call_id?: string;
   }) => Promise<ClientToolMessageInput> | ClientToolMessageInput;
+
+  /**
+   * Resolves private, immutable tool-output attachments for display.
+   *
+   * The handler should authorize the current user, pin the requested Artifact
+   * version, and return a short-lived preview URL. ChatKit never persists the
+   * returned URL and calls the handler again after expiry or page reload.
+   */
+  toolOutputAttachments?: {
+    onRequestPreview: (
+      request: ToolOutputAttachmentPreviewRequest,
+    ) => Promise<ToolOutputAttachmentPreview> | ToolOutputAttachmentPreview;
+  };
 
   /**
    * Whether to show the header in ChatKit. A configuration object can be

--- a/packages/chatkit/src/tool-output.ts
+++ b/packages/chatkit/src/tool-output.ts
@@ -1,0 +1,83 @@
+export const TOOL_OUTPUT_PRESENTATION_TYPE = 'xpert.tool-output' as const;
+export const TOOL_OUTPUT_PRESENTATION_VERSION = 1 as const;
+
+export type ToolOutputImageMimeType = 'image/png' | 'image/jpeg' | 'image/webp';
+
+export type ToolOutputImageSource = 'knowledge-document' | 'sandbox';
+
+/**
+ * Stable evidence anchors that are safe to persist in chat history.
+ *
+ * Execution-scoped file paths, storage paths, signed URLs, and internal batch
+ * references must not be included here.
+ */
+export type ToolOutputImageAnchors = {
+  knowledgeDocumentId?: string;
+  page?: number;
+  chunkId?: string;
+  sourceBlockIds?: string[];
+  visualAssetId?: string;
+};
+
+/**
+ * An immutable image that was prepared for a model vision step.
+ *
+ * Chat history stores only the private Artifact identity and presentation
+ * metadata. The browser asks the trusted host to resolve a short-lived preview
+ * URL when the image is rendered.
+ */
+export type ToolOutputImageAttachment = {
+  type: 'image';
+  artifactId: string;
+  artifactVersionId: string;
+  sha256: string;
+  mimeType: ToolOutputImageMimeType;
+  width?: number;
+  height?: number;
+  title?: string;
+  alt?: string;
+  source: ToolOutputImageSource;
+  modelDetail: ImageDetail;
+  anchors?: ToolOutputImageAnchors;
+};
+
+export type ToolOutputAttachment = ToolOutputImageAttachment;
+
+/**
+ * UI-only ToolMessage artifact. ToolMessage content remains the compact
+ * model-facing result, while middleware metadata remains private to the model
+ * execution path.
+ */
+export type ToolOutputPresentation = {
+  type: typeof TOOL_OUTPUT_PRESENTATION_TYPE;
+  version: typeof TOOL_OUTPUT_PRESENTATION_VERSION;
+  attachments: ToolOutputAttachment[];
+};
+
+export type ToolOutputArtifactJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ToolOutputArtifactJsonValue[]
+  | { [key: string]: ToolOutputArtifactJsonValue };
+
+/** JSON-safe artifact payloads supported by ToolMessage history. */
+export type ToolMessageArtifact =
+  | ToolOutputPresentation
+  | ToolOutputArtifactJsonValue;
+
+export type ToolOutputAttachmentPreviewRequest = {
+  attachment: ToolOutputImageAttachment;
+  toolCallId?: string;
+  executionId?: string;
+};
+
+export type ToolOutputAttachmentPreview = {
+  /** Short-lived, host-authorized URL. Never persist this value in a message. */
+  previewUrl: string;
+  expiresAt?: string;
+};
+
+/** Detail level requested for the model vision input. */
+export type ImageDetail = 'auto' | 'low' | 'high';

--- a/packages/web-component/src/ChatKitElementBase.ts
+++ b/packages/web-component/src/ChatKitElementBase.ts
@@ -8,6 +8,7 @@ import type {
   ChatKitOptions,
   Entity,
   ListView,
+  ToolOutputAttachmentPreviewRequest,
 } from '@xpert-ai/chatkit-types';
 import { normalizePetOptions } from '@xpert-ai/chatkit-types';
 import type { ChatKitReference } from '@xpert-ai/chatkit-types';
@@ -162,6 +163,20 @@ export abstract class ChatKitElementBase<TRawOptions> extends HTMLElement {
           );
         }
         return onClientTool({ name, params, id, tool_call_id });
+      },
+      onToolOutputAttachmentPreview: async (
+        request: ToolOutputAttachmentPreviewRequest,
+      ) => {
+        const onRequestPreview =
+          this.#opts?.toolOutputAttachments?.onRequestPreview;
+        if (!onRequestPreview) {
+          this.#emitAndThrow(
+            new IntegrationError(
+              'No handler for tool-output attachment previews. Add toolOutputAttachments.onRequestPreview to your ChatKit options.',
+            ),
+          );
+        }
+        return onRequestPreview(request);
       },
       onWorkbenchClientCommand: async ({
         commandKey,


### PR DESCRIPTION
## Summary

- restore active thread streams from the newest pending or running execution, including the window before the first assistant message is persisted
- add a secure `xpert.tool-output` image attachment protocol with immutable artifact metadata and host-authorized short-lived preview URLs
- render localized inline image galleries and accessible full-image previews for tool results
- improve tool input labeling and clamp long start-screen prompt labels
- add ChatKit type exports, web-component host wiring, documentation, and a changeset for the new attachment API

## Why

Conversation loading previously depended on an assistant message to recover the execution ID, so a newly created run could be missed before that message existed. Tool-generated images also lacked a typed, secure presentation path that avoids persisting signed URLs, storage paths, or base64 payloads.

## Impact

Hosts can resume active executions more reliably and can authorize immutable tool-output image previews on demand. Existing integrations remain compatible; hosts only need to provide `toolOutputAttachments.onRequestPreview` when they render these attachments.

## Validation

- Added unit coverage for active-run selection and retry behavior
- Added parser coverage for accepted attachment descriptors and rejection of embedded URLs, base64 data, SVG, invalid hashes, and unsafe preview schemes
- Added UI coverage for rendering image artifacts before raw tool output
- No CI checks were reported for head commit `cfae5c6` before opening this PR; PR checks are pending
