### PR TITLE
[codex] Fix DingTalk WebView ChatKit bridge

### DIFF
--- a/.changeset/fix-dingtalk-webview-message-channel.md
+++ b/.changeset/fix-dingtalk-webview-message-channel.md
@@ -1,0 +1,8 @@
+---
+'@xpert-ai/chatkit-ui': patch
+'@xpert-ai/chatkit-web-component': patch
+'@xpert-ai/chatkit-web-shared': patch
+---
+
+Authenticate iframe messages with a per-frame channel when embedded WebViews expose non-canonical window source proxies.
+Defer composer state synchronization until IME composition ends in embedded WebViews.

--- a/packages/chatkit-ui/src/components/chat.plan-mode.test.tsx
+++ b/packages/chatkit-ui/src/components/chat.plan-mode.test.tsx
@@ -2235,16 +2235,17 @@ describe('Chat plan mode payload', () => {
     renderChat();
 
     const textbox = screen.getByRole('textbox');
+    const send = screen.getByRole('button', { name: 'send' });
     fireEvent.compositionStart(textbox);
     textbox.textContent = 'pin';
-    fireEvent.input(textbox);
+    fireEvent.input(textbox, { isComposing: true });
     expect(screen.getByRole('textbox')).toBe(textbox);
+    expect(send).toBeDisabled();
 
     textbox.textContent = '拼';
     fireEvent.compositionEnd(textbox);
     expect(screen.getByRole('textbox')).toBe(textbox);
 
-    const send = screen.getByRole('button', { name: 'send' });
     await waitFor(() => expect(send).not.toBeDisabled());
     fireEvent.click(send);
 

--- a/packages/chatkit-ui/src/components/chat.tsx
+++ b/packages/chatkit-ui/src/components/chat.tsx
@@ -614,6 +614,7 @@ export function Chat({
   );
   const attachmentsRef = React.useRef<ChatAttachmentsHandle>(null);
   const composerInputRef = React.useRef<HTMLDivElement>(null);
+  const isComposerComposingRef = React.useRef(false);
   const slashPaletteRef = React.useRef<HTMLDivElement>(null);
   const slashPaletteOptionRefs = React.useRef<Array<HTMLButtonElement | null>>(
     [],
@@ -1608,13 +1609,20 @@ export function Chat({
 
   const handleComposerInput = React.useCallback(
     (event: React.FormEvent<HTMLDivElement>) => {
+      if (isComposerComposingRef.current) return;
+
       syncComposerInputFromElement(event.currentTarget);
     },
     [syncComposerInputFromElement],
   );
 
+  const handleComposerCompositionStart = React.useCallback(() => {
+    isComposerComposingRef.current = true;
+  }, []);
+
   const handleComposerCompositionEnd = React.useCallback(
     (event: React.CompositionEvent<HTMLDivElement>) => {
+      isComposerComposingRef.current = false;
       syncComposerInputFromElement(event.currentTarget);
     },
     [syncComposerInputFromElement],
@@ -3570,6 +3578,7 @@ export function Chat({
               }
               suppressContentEditableWarning
               onInput={handleComposerInput}
+              onCompositionStart={handleComposerCompositionStart}
               onCompositionEnd={handleComposerCompositionEnd}
               onSelect={handleComposerSelect}
               onPaste={handleComposerPaste}

--- a/packages/chatkit-ui/src/main.tsx
+++ b/packages/chatkit-ui/src/main.tsx
@@ -22,20 +22,31 @@ const getParentOrigin = () => {
 /**
  * Decode base64 options from URL hash
  */
-function decodeOptionsFromUrl(): ChatKitOptions | null {
-  if (typeof window === 'undefined') return null;
+type ChatKitFrameUrlParams = {
+  channelId?: string;
+  options?: ChatKitOptions;
+};
+
+function decodeFrameParamsFromUrl(): ChatKitFrameUrlParams {
+  if (typeof window === 'undefined') return {};
 
   const hash = window.location.hash;
   const encoded = hash.startsWith('#') ? hash.slice(1) : hash;
 
-  if (!encoded) return null;
+  if (!encoded) return {};
 
   try {
-    const params = decodeBase64<{ options?: ChatKitOptions }>(encoded);
-    return params?.options ?? null;
+    const params = decodeBase64<ChatKitFrameUrlParams>(encoded);
+    return {
+      channelId:
+        typeof params?.channelId === 'string' && params.channelId.trim()
+          ? params.channelId
+          : undefined,
+      options: params?.options,
+    };
   } catch (error) {
     console.warn('[chatkit-ui] Failed to decode options from URL hash:', error);
-    return null;
+    return {};
   }
 }
 
@@ -45,7 +56,8 @@ const initialClientSecret =
     : new URLSearchParams(window.location.search).get('clientSecret') ?? '';
 
 // Parse options from URL on initial load
-const initialOptions = decodeOptionsFromUrl();
+const initialFrameParams = decodeFrameParamsFromUrl();
+const initialOptions = initialFrameParams.options ?? null;
 
 const AppContainer = () => {
   const [clientSecret, setClientSecret] = React.useState(initialClientSecret);
@@ -149,7 +161,7 @@ const AppContainer = () => {
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <NuqsAdapter>
-      <ParentMessengerProvider>
+      <ParentMessengerProvider channelId={initialFrameParams.channelId}>
         <AppContainer />
       </ParentMessengerProvider>
     </NuqsAdapter>

--- a/packages/chatkit-ui/src/providers/ParentMessenger.test.tsx
+++ b/packages/chatkit-ui/src/providers/ParentMessenger.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isTrustedChatKitMessageEvent } from '@xpert-ai/chatkit-web-shared';
 
 const mocks = vi.hoisted(() => ({
   stream: {
@@ -79,6 +80,28 @@ describe('ParentMessengerProvider', () => {
       configurable: true,
       value: originalParent,
     });
+  });
+
+  it('does not let a matching channel bypass the expected origin', () => {
+    const event = new MessageEvent('message', {
+      data: {
+        __xpaiChatKit: true,
+        channelId: 'matching-channel',
+      },
+      origin: 'https://untrusted.example.com',
+    });
+    Object.defineProperty(event, 'source', {
+      configurable: true,
+      value: { postMessage: vi.fn() },
+    });
+
+    expect(
+      isTrustedChatKitMessageEvent(event, {
+        channelId: 'matching-channel',
+        expectedOrigin: 'https://trusted.example.com',
+        expectedSource: window,
+      }),
+    ).toBe(false);
   });
 
   it('passes planMode through sendUserMessage input and state', async () => {
@@ -351,6 +374,85 @@ describe('ParentMessengerProvider', () => {
       }),
       '*',
     );
+  });
+
+  it('accepts a matching channel when a WebView exposes a different parent source proxy', async () => {
+    const onSetComposerValue = vi.fn();
+    render(
+      <ParentMessengerProvider channelId="dingtalk-channel">
+        <ComposerValueProbe onSetComposerValue={onSetComposerValue} />
+      </ParentMessengerProvider>,
+    );
+
+    const data = {
+      __xpaiChatKit: true,
+      channelId: 'dingtalk-channel',
+      type: 'command',
+      command: 'onSetComposerValue',
+      nonce: 'dingtalk-source-proxy-test',
+      data: {
+        text: 'Bridge restored',
+      },
+    };
+    const event = new MessageEvent('message', {
+      data,
+      origin: 'https://example.com',
+    });
+    Object.defineProperty(event, 'source', {
+      configurable: true,
+      value: { postMessage: vi.fn() },
+    });
+
+    window.dispatchEvent(event);
+
+    await waitFor(() =>
+      expect(onSetComposerValue).toHaveBeenCalledWith({
+        text: 'Bridge restored',
+      }),
+    );
+    expect(parentWindow.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        __xpaiChatKit: true,
+        channelId: 'dingtalk-channel',
+        type: 'response',
+        nonce: 'dingtalk-source-proxy-test',
+        response: { ok: true },
+      }),
+      '*',
+    );
+  });
+
+  it('rejects an incorrect channel when the parent source also differs', async () => {
+    const onSetComposerValue = vi.fn();
+    render(
+      <ParentMessengerProvider channelId="expected-channel">
+        <ComposerValueProbe onSetComposerValue={onSetComposerValue} />
+      </ParentMessengerProvider>,
+    );
+
+    const event = new MessageEvent('message', {
+      data: {
+        __xpaiChatKit: true,
+        channelId: 'wrong-channel',
+        type: 'command',
+        command: 'onSetComposerValue',
+        nonce: 'wrong-channel-test',
+        data: {
+          text: 'Do not accept this',
+        },
+      },
+      origin: 'https://example.com',
+    });
+    Object.defineProperty(event, 'source', {
+      configurable: true,
+      value: { postMessage: vi.fn() },
+    });
+
+    window.dispatchEvent(event);
+    await Promise.resolve();
+
+    expect(onSetComposerValue).not.toHaveBeenCalled();
+    expect(parentWindow.postMessage).not.toHaveBeenCalled();
   });
 
   it('sends chat minimize events to the parent frame', () => {

--- a/packages/chatkit-ui/src/providers/ParentMessenger.tsx
+++ b/packages/chatkit-ui/src/providers/ParentMessenger.tsx
@@ -15,7 +15,10 @@ import {
   type SendUserMessageParams,
   type ToolOutputAttachmentPreviewRequest,
 } from '@xpert-ai/chatkit-types';
-import type { Capability } from '@xpert-ai/chatkit-web-shared';
+import {
+  isTrustedChatKitMessageEvent,
+  type Capability,
+} from '@xpert-ai/chatkit-web-shared';
 import type { Message } from '@xpert-ai/xpert-sdk';
 import { useStreamManager } from '../hooks/useStream';
 import { buildInjectedRequestOptions } from '../lib/request-options';
@@ -101,7 +104,10 @@ type ParentMessage =
   | ParentResponseMessage
   | ParentEventMessage;
 
-type ParentEnvelope = Partial<ParentMessage> & { __xpaiChatKit: true };
+type ParentEnvelope = Partial<ParentMessage> & {
+  __xpaiChatKit: true;
+  channelId?: string;
+};
 
 const handledSendUserMessageNonces = new Set<string>();
 const handledSendUserMessageEvents = new WeakSet<MessageEvent>();
@@ -162,10 +168,12 @@ export const ParentMessengerContext =
   createContext<ParentMessengerContextValue | null>(null);
 
 export type ParentMessengerProviderProps = {
+  channelId?: string;
   children: ReactNode;
 };
 
 export function ParentMessengerProvider({
+  channelId,
   children,
 }: ParentMessengerProviderProps) {
   const { streamRef } = useStreamManager();
@@ -252,6 +260,7 @@ export function ParentMessengerProvider({
     ) => {
       const message: ParentEnvelope = {
         __xpaiChatKit: true,
+        ...(channelId ? { channelId } : {}),
         type: 'response',
         nonce,
         response,
@@ -261,18 +270,17 @@ export function ParentMessengerProvider({
     };
 
     const handleMessage = (event: MessageEvent) => {
-      if (event.source !== window.parent) return;
-      if (!event.data || typeof event.data !== 'object') return;
       if (
-        parentOriginRef.current !== '*' &&
-        typeof event.origin === 'string' &&
-        event.origin !== parentOriginRef.current
+        !isTrustedChatKitMessageEvent(event, {
+          channelId,
+          expectedOrigin: parentOriginRef.current,
+          expectedSource: window.parent,
+        })
       ) {
         return;
       }
 
-      const payload = event.data as Partial<ParentEnvelope>;
-      if (payload.__xpaiChatKit !== true) return;
+      const payload = event.data as ParentEnvelope;
 
       if (
         payload.type === 'command' &&
@@ -541,7 +549,7 @@ export function ParentMessengerProvider({
       });
       pendingRef.current.clear();
     };
-  }, [isParentAvailable, streamRef]);
+  }, [channelId, isParentAvailable, streamRef]);
 
   const sendCommand = useCallback(
     <K extends keyof CommandMessageMap>(
@@ -556,6 +564,7 @@ export function ParentMessengerProvider({
       const nonce = createNonce();
       const message: ParentEnvelope = {
         __xpaiChatKit: true,
+        ...(channelId ? { channelId } : {}),
         type: 'command',
         nonce,
         command,
@@ -567,7 +576,7 @@ export function ParentMessengerProvider({
         window.parent.postMessage(message, parentOriginRef.current, transfer);
       });
     },
-    [isParentAvailable],
+    [channelId, isParentAvailable],
   );
 
   const sendEvent = useCallback(
@@ -589,13 +598,14 @@ export function ParentMessengerProvider({
       if (!isParentAvailable) return;
       const message: ParentEnvelope = {
         __xpaiChatKit: true,
+        ...(channelId ? { channelId } : {}),
         type: 'event',
         event,
         data,
       };
       window.parent.postMessage(message, parentOriginRef.current, transfer);
     },
-    [isParentAvailable],
+    [channelId, isParentAvailable],
   );
 
   const value = useMemo(

--- a/packages/chatkit-web-shared/src/BaseMessenger.ts
+++ b/packages/chatkit-web-shared/src/BaseMessenger.ts
@@ -2,6 +2,7 @@ import type { EventSourceMessage, FetchEventSourceInit } from "@microsoft/fetch-
 import { EventEmitter } from "./EventEmitter"
 import { fetchEventSourceWithRetry } from "./fetchEventSourceWithRetry.js"
 import { safeRandomUUID } from "./safeRandomUUID.js"
+import { isTrustedChatKitMessageEvent } from "./messageChannel.js"
 import type { AnyFunction } from "./types"
 import { FrameSafeHttpError, HttpError } from "./errors/HttpError"
 import { FrameSafeIntegrationError, IntegrationError } from "./errors/IntegrationError"
@@ -60,6 +61,7 @@ export abstract class BaseMessenger<
 > {
   private targetOrigin: string
   private target: () => Window | null
+  private channelId?: string
   private commandHandlers: Record<string, AnyFunction>
   private _fetch: typeof window.fetch
 
@@ -70,10 +72,12 @@ export abstract class BaseMessenger<
     handlers,
     target,
     targetOrigin,
+    channelId,
     fetch = window.fetch,
   }: {
     target: () => Window | null
     targetOrigin: string
+    channelId?: string
     fetch?: typeof window.fetch
     handlers: {
       [K in keyof ReceivedCommands as K extends `${infer C}${infer S}`
@@ -86,6 +90,7 @@ export abstract class BaseMessenger<
     this.commandHandlers = handlers
     this.target = target
     this.targetOrigin = targetOrigin
+    this.channelId = channelId?.trim() || undefined
     this._fetch = ((...args) => fetch(...args)) as typeof window.fetch
   }
 
@@ -110,6 +115,7 @@ export abstract class BaseMessenger<
   private sendMessage(data: ChatKitMessage, transfer?: Transferable[]) {
     const message = {
       __xpaiChatKit: true,
+      ...(this.channelId ? { channelId: this.channelId } : {}),
       ...data,
     }
     this.target()?.postMessage(message, this.targetOrigin, transfer)
@@ -244,10 +250,11 @@ export abstract class BaseMessenger<
 
   private handleMessage = async (event: MessageEvent) => {
     if (
-      !event.data ||
-      event.data.__xpaiChatKit !== true ||
-      event.origin !== this.targetOrigin ||
-      event.source !== this.target()
+      !isTrustedChatKitMessageEvent(event, {
+        channelId: this.channelId,
+        expectedOrigin: this.targetOrigin,
+        expectedSource: this.target(),
+      })
     ) {
       return
     }

--- a/packages/chatkit-web-shared/src/index.ts
+++ b/packages/chatkit-web-shared/src/index.ts
@@ -1,5 +1,7 @@
 export * from './BaseMessenger'
 export * from './frameEncoding'
+export * from './messageChannel'
+export { createSecureChannelId } from './safeRandomUUID'
 export * from './types/index'
 export * from './types/capabilities.types'
 export * from './capabilities'

--- a/packages/chatkit-web-shared/src/messageChannel.ts
+++ b/packages/chatkit-web-shared/src/messageChannel.ts
@@ -1,0 +1,35 @@
+export type ChatKitMessageChannel = {
+  channelId?: string
+  expectedOrigin: string
+  expectedSource: MessageEventSource | null
+}
+
+export function isTrustedChatKitMessageEvent(
+  event: MessageEvent,
+  { channelId, expectedOrigin, expectedSource }: ChatKitMessageChannel,
+): boolean {
+  const payload = event.data
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    !("__xpaiChatKit" in payload)
+  ) {
+    return false
+  }
+  if (payload.__xpaiChatKit !== true) {
+    return false
+  }
+  if (expectedOrigin !== "*" && event.origin !== expectedOrigin) {
+    return false
+  }
+  if (event.source === expectedSource) {
+    return true
+  }
+
+  const normalizedChannelId = channelId?.trim()
+  if (normalizedChannelId) {
+    return "channelId" in payload && payload.channelId === normalizedChannelId
+  }
+
+  return false
+}

--- a/packages/chatkit-web-shared/src/safeRandomUUID.ts
+++ b/packages/chatkit-web-shared/src/safeRandomUUID.ts
@@ -1,4 +1,4 @@
-export function safeRandomUUID(): string {
+export function createSecureChannelId(): string | null {
   const cryptoRef = globalThis.crypto
 
   if (typeof cryptoRef?.randomUUID === "function") {
@@ -18,5 +18,12 @@ export function safeRandomUUID(): string {
       .replace(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/, "$1-$2-$3-$4-$5")
   }
 
-  return `ck_${Date.now()}_${Math.random().toString(16).slice(2)}`
+  return null
+}
+
+export function safeRandomUUID(): string {
+  return (
+    createSecureChannelId() ??
+    `ck_${Date.now()}_${Math.random().toString(16).slice(2)}`
+  )
 }

--- a/packages/web-component/src/ChatKitElementBase.ts
+++ b/packages/web-component/src/ChatKitElementBase.ts
@@ -1,6 +1,9 @@
 /// <reference path="./import-meta-env.d.ts" />
 
-import { encodeBase64 } from '@xpert-ai/chatkit-web-shared';
+import {
+  createSecureChannelId,
+  encodeBase64,
+} from '@xpert-ai/chatkit-web-shared';
 
 import { ChatFrameMessenger } from './ChatFrameMessenger';
 import type {
@@ -111,8 +114,10 @@ export abstract class ChatKitElementBase<TRawOptions> extends HTMLElement {
   #loaded = new Promise<void>((resolve) => {
     this.#resolveLoaded = resolve;
   });
+  #channelId = createSecureChannelId();
 
   #messenger = new ChatFrameMessenger({
+    channelId: this.#channelId ?? undefined,
     fetch: ((...args) => {
       const customFetch =
         this.#opts?.api && 'fetch' in this.#opts.api && this.#opts.api.fetch;
@@ -840,6 +845,7 @@ export abstract class ChatKitElementBase<TRawOptions> extends HTMLElement {
       options: getInnerOptions(this.#getFrameOptions(this.#opts)),
       referrer: window.location.origin,
       profile: this.profile,
+      ...(this.#channelId ? { channelId: this.#channelId } : {}),
     } satisfies ChatKitFrameParams);
     this.#messenger.connect();
     this.#frame.src = frameURL.toString();


### PR DESCRIPTION
## Summary

- add a per-frame cryptographic message channel so DingTalk WebViews can bridge iframe messages when `event.source` is proxied
- retain origin validation and strict source matching when no secure channel is available
- defer composer state synchronization during IME composition to avoid duplicated CJK input

## Root cause

DingTalk's WebView can expose a different `WindowProxy` for `postMessage` events. The previous strict `event.source` identity check therefore dropped valid messages between the web component and ChatKit iframe, leaving the embedded view stuck loading. The composer also synchronized the controlled `contenteditable` state on intermediate input events while the IME still owned the DOM, which could duplicate composed text.

The fix keeps origin validation mandatory and allows a source mismatch only when both sides present the same cryptographically random, per-frame channel ID. If secure randomness is unavailable, the relaxed path is disabled and the original strict source check remains. During IME composition, input state synchronization is deferred until `compositionend`.

## Validation

- `@xpert-ai/chatkit-ui`: 64 test files, 484 tests passed
- `@xpert-ai/chatkit-ui`: types passed
- `@xpert-ai/chatkit-web-component`: type-check passed
- `@xpert-ai/chatkit-web-shared`: build passed
- `@xpert-ai/chatkit-ui`: build passed
- `@xpert-ai/chatkit-web-component`: build passed
- `git diff --check` passed

## Notes

- The standalone `@xpert-ai/chatkit-web-shared` types command still hits a pre-existing `ImportMetaEnv.DEV` declaration-modifier conflict with Vite; package build and declaration generation pass.
- Real DingTalk manual acceptance remains to be run in the host app.
