### PR TITLE
[codex] Support SDK-backed MCP Apps

### DIFF
--- a/.changeset/calm-mcp-apps-connect.md
+++ b/.changeset/calm-mcp-apps-connect.md
@@ -1,0 +1,6 @@
+---
+'@xpert-ai/chatkit-ui': patch
+'@xpert-ai/chatkit-types': patch
+---
+
+Use the Xpert SDK for MCP App runtime requests and add isolated sandbox, approval, teardown, display mode, message, and download support.

--- a/packages/chatkit-ui/package.json
+++ b/packages/chatkit-ui/package.json
@@ -38,7 +38,7 @@
     "@xpert-ai/a2ui-react": "workspace:~",
     "@xpert-ai/chatkit-types": "workspace:~",
     "@xpert-ai/chatkit-web-shared": "workspace:~",
-    "@xpert-ai/xpert-sdk": "^0.0.15",
+    "@xpert-ai/xpert-sdk": "^0.0.16",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.4.9",

--- a/packages/chatkit-ui/public/mcp-app-sandbox-proxy.html
+++ b/packages/chatkit-ui/public/mcp-app-sandbox-proxy.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; frame-src 'self'; object-src 'none'; base-uri 'none'; form-action 'none'"
+    />
+    <meta name="referrer" content="no-referrer" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>MCP App Sandbox</title>
+    <style>
+      html,
+      body,
+      #app {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+      }
+
+      iframe {
+        display: block;
+        width: 100%;
+        height: 100%;
+        border: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script>
+      (() => {
+        const params = new URLSearchParams(window.location.hash.slice(1));
+        const parentOrigin = params.get('parentOrigin');
+        const container = document.getElementById('app');
+        let appFrame = null;
+
+        function isAllowedParentOrigin(value) {
+          if (!value) return false;
+          try {
+            const url = new URL(value);
+            return (
+              url.origin === value &&
+              (url.protocol === 'https:' ||
+                (url.protocol === 'http:' &&
+                  (url.hostname === 'localhost' ||
+                    url.hostname === '127.0.0.1' ||
+                    url.hostname === '[::1]')))
+            );
+          } catch {
+            return false;
+          }
+        }
+
+        if (!container || !isAllowedParentOrigin(parentOrigin)) return;
+
+        function postToHost(message) {
+          window.parent.postMessage(message, parentOrigin);
+        }
+
+        function iframeAllow(permissions) {
+          if (!permissions || typeof permissions !== 'object') return '';
+          const policies = [];
+          if (permissions.camera) policies.push('camera *');
+          if (permissions.microphone) policies.push('microphone *');
+          if (permissions.geolocation) policies.push('geolocation *');
+          if (permissions.clipboardWrite) policies.push('clipboard-write *');
+          return policies.join('; ');
+        }
+
+        function loadResource(params) {
+          if (!params || typeof params.html !== 'string' || appFrame) return;
+          const iframe = document.createElement('iframe');
+          iframe.title = 'MCP App';
+          iframe.referrerPolicy = 'no-referrer';
+          iframe.sandbox.value =
+            typeof params.sandbox === 'string'
+              ? params.sandbox
+              : 'allow-forms allow-modals allow-scripts';
+          const allow = iframeAllow(params.permissions);
+          if (allow) iframe.allow = allow;
+          iframe.srcdoc = params.html;
+          appFrame = iframe;
+          container.replaceChildren(iframe);
+        }
+
+        window.addEventListener('message', (event) => {
+          if (event.source === window.parent) {
+            if (event.origin !== parentOrigin) return;
+            if (
+              event.data?.method === 'ui/notifications/sandbox-resource-ready'
+            ) {
+              loadResource(event.data.params);
+              return;
+            }
+            appFrame?.contentWindow?.postMessage(event.data, '*');
+            return;
+          }
+
+          if (appFrame && event.source === appFrame.contentWindow) {
+            postToHost(event.data);
+          }
+        });
+
+        postToHost({
+          jsonrpc: '2.0',
+          method: 'ui/notifications/sandbox-proxy-ready',
+          params: {},
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/packages/chatkit-ui/src/components/chat.tsx
+++ b/packages/chatkit-ui/src/components/chat.tsx
@@ -3121,6 +3121,7 @@ export function Chat({
                           organizationId={stream.organizationId}
                           apiUrl={stream.apiUrl}
                           pet={effectivePet}
+                          mcpApps={options?.mcpApps}
                         />
                       ) : (
                         <>

--- a/packages/chatkit-ui/src/components/thread/messages/ai.tsx
+++ b/packages/chatkit-ui/src/components/thread/messages/ai.tsx
@@ -68,6 +68,15 @@ export type AssistantMessageProps = {
   organizationId?: string;
   apiUrl?: string;
   pet?: ChatKitOptions['pet'] | null;
+  mcpApps?: ChatKitOptions['mcpApps'];
+};
+
+type AssistantContentRenderOptions = {
+  isThreadRunning?: boolean;
+  organizationId?: string;
+  apiUrl?: string;
+  isAgentOutput?: boolean;
+  mcpApps?: ChatKitOptions['mcpApps'];
 };
 
 const assistantMessageStackClassName =
@@ -425,12 +434,7 @@ function renderContentItem(
   index: number,
   message: ChatkitMessage,
   lookupMessages: ChatkitMessage[],
-  options?: {
-    isThreadRunning?: boolean;
-    organizationId?: string;
-    apiUrl?: string;
-    isAgentOutput?: boolean;
-  },
+  options?: AssistantContentRenderOptions,
 ): React.ReactNode {
   const messageId = message.id;
   const textClassName = options?.isAgentOutput
@@ -508,7 +512,11 @@ function renderContentItem(
     if (isMcpAppComponent(content)) {
       return (
         <div key={content.id ?? `mcp-app-${index}`}>
-          <McpAppMessage messageId={messageId} data={content.data} />
+          <McpAppMessage
+            messageId={messageId}
+            data={content.data}
+            mcpApps={options?.mcpApps}
+          />
         </div>
       );
     }
@@ -565,12 +573,7 @@ function renderContentUnit(
   message: ChatkitMessage,
   lookupMessages: ChatkitMessage[],
   hasFollowingItem: boolean,
-  options?: {
-    isThreadRunning?: boolean;
-    organizationId?: string;
-    apiUrl?: string;
-    isAgentOutput?: boolean;
-  },
+  options?: AssistantContentRenderOptions,
 ): React.ReactNode {
   if (unit.type === 'item') {
     return renderContentItem(unit.item, unit.index, message, lookupMessages, {
@@ -578,6 +581,7 @@ function renderContentUnit(
       organizationId: options?.organizationId,
       apiUrl: options?.apiUrl,
       isAgentOutput: options?.isAgentOutput,
+      mcpApps: options?.mcpApps,
     });
   }
 
@@ -599,12 +603,7 @@ function renderEntryBatch(
   message: ChatkitMessage,
   lookupMessages: ChatkitMessage[],
   hasFollowingItem: boolean,
-  options?: {
-    isThreadRunning?: boolean;
-    organizationId?: string;
-    apiUrl?: string;
-    isAgentOutput?: boolean;
-  },
+  options?: AssistantContentRenderOptions,
 ) {
   if (entries.length === 0) return null;
 
@@ -632,12 +631,7 @@ function renderAssistantRenderUnits(
   units: AssistantRenderUnit[],
   message: ChatkitMessage,
   lookupMessages: ChatkitMessage[],
-  options?: {
-    isThreadRunning?: boolean;
-    organizationId?: string;
-    apiUrl?: string;
-    isAgentOutput?: boolean;
-  },
+  options?: AssistantContentRenderOptions,
   depth = 0,
 ) {
   const rendered: React.ReactNode[] = [];
@@ -693,11 +687,7 @@ function renderAssistantRenderUnits(
 function renderContent(
   message: ChatkitMessage,
   lookupMessages: ChatkitMessage[],
-  options?: {
-    isThreadRunning?: boolean;
-    organizationId?: string;
-    apiUrl?: string;
-  },
+  options?: AssistantContentRenderOptions,
 ) {
   const renderTree = buildAssistantRenderTree(
     message as AssistantMessageWithAgentRuns,
@@ -795,6 +785,7 @@ export function AssistantMessage({
   organizationId,
   apiUrl,
   pet,
+  mcpApps,
 }: AssistantMessageProps) {
   const { t } = useChatkitTranslation();
   const renderTree = buildAssistantRenderTree(
@@ -820,6 +811,7 @@ export function AssistantMessage({
     isThreadRunning,
     organizationId,
     apiUrl,
+    mcpApps,
   });
   const reasoningNode = hasReasoning ? (
     <ReasoningBlock reasoning={rootReasoning ?? []} />

--- a/packages/chatkit-ui/src/components/thread/messages/mcp-app.component.test.tsx
+++ b/packages/chatkit-ui/src/components/thread/messages/mcp-app.component.test.tsx
@@ -1,0 +1,723 @@
+import * as React from 'react';
+import type { TMessageComponentMcpAppData } from '@xpert-ai/chatkit-types';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const getResource = vi.fn();
+  const rpc = vi.fn();
+  const approve = vi.fn();
+  const reject = vi.fn();
+  const teardown = vi.fn();
+  return {
+    getResource,
+    rpc,
+    approve,
+    reject,
+    teardown,
+    submit: vi.fn(),
+    client: {
+      mcp: {
+        apps: { getResource, rpc, approve, reject, teardown },
+      },
+    },
+  };
+});
+
+vi.mock('../../../providers/Stream', () => ({
+  useStreamContext: () => ({
+    client: mocks.client,
+    isLoading: false,
+    submit: mocks.submit,
+  }),
+}));
+
+vi.mock('../../../i18n/useChatkitTranslation', () => ({
+  useChatkitTranslation: () => ({
+    i18n: {
+      language: 'en-US',
+      t: (key: string, values?: { tool?: string }) => {
+        const translations: Record<string, string> = {
+          'message.mcpApp.loading': 'Loading MCP App',
+          'message.mcpApp.fullscreen': 'Open fullscreen',
+          'message.mcpApp.pictureInPicture': 'Open picture in picture',
+          'message.mcpApp.returnInline': 'Return inline',
+          'message.mcpApp.approvalTitle': 'Confirm MCP App action',
+          'message.mcpApp.toolApprovalDescription': `Run ${values?.tool ?? ''}`,
+          'message.mcpApp.downloadApprovalDescription': 'Download files',
+          'message.mcpApp.requestDetails': 'Request details',
+          'message.mcpApp.approve': 'Allow',
+          'message.mcpApp.reject': 'Reject',
+        };
+        return translations[key] ?? key;
+      },
+    },
+  }),
+}));
+
+import { McpAppMessage, resolveMcpAppSandboxProxy } from './mcp-app';
+
+function asIframe(element: HTMLElement) {
+  if (!(element instanceof HTMLIFrameElement)) {
+    throw new Error('Expected MCP App to render an iframe');
+  }
+  return element;
+}
+
+function getIframeWindow(iframe: HTMLIFrameElement) {
+  const iframeWindow = iframe.contentWindow;
+  if (!iframeWindow) {
+    throw new Error('Expected MCP App iframe to have a content window');
+  }
+  return iframeWindow;
+}
+
+const data: TMessageComponentMcpAppData = {
+  type: 'McpApp',
+  appInstanceId: 'app-1',
+  appInstanceToken: 'initial-token',
+  resourceUri: 'ui://example/app.html',
+  toolName: 'initial_tool',
+  toolCallId: 'call-1',
+  toolsetId: 'toolset-1',
+  serverName: 'example',
+  title: 'Example App',
+};
+
+describe('McpAppMessage host controls', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    Reflect.deleteProperty(URL, 'createObjectURL');
+    Reflect.deleteProperty(URL, 'revokeObjectURL');
+    mocks.getResource.mockResolvedValue({
+      uri: data.resourceUri,
+      text: '<!doctype html><html><body>App</body></html>',
+      appInstanceToken: 'runtime-token',
+      toolInput: {},
+      toolInfo: {
+        name: data.toolName,
+        inputSchema: { type: 'object', properties: {} },
+      },
+    });
+    mocks.approve.mockResolvedValue({ approved: true });
+    mocks.reject.mockResolvedValue({ approved: false, rejected: true });
+    mocks.teardown.mockResolvedValue(undefined);
+  });
+
+  it('requires visible approval and retries the exact tool call with approvalId', async () => {
+    const expiresAt = Date.now() + 60_000;
+    mocks.rpc
+      .mockResolvedValueOnce({
+        jsonrpc: '2.0',
+        id: 'rpc-1',
+        error: {
+          code: -32001,
+          message: 'Approval required',
+          data: { approvalId: 'approval-1', risk: 'write', expiresAt },
+        },
+      })
+      .mockResolvedValueOnce({
+        jsonrpc: '2.0',
+        id: 'rpc-1',
+        result: { content: [{ type: 'text', text: 'updated' }] },
+      });
+
+    render(<McpAppMessage data={data} messageId="message-1" />);
+    const iframe = asIframe(await screen.findByTitle('Example App'));
+    expect(iframe.getAttribute('sandbox')).not.toContain('allow-downloads');
+    expect(iframe.getAttribute('sandbox')).not.toContain('allow-same-origin');
+    expect(iframe.srcdoc).toContain("form-action 'none'");
+    const postMessage = vi.spyOn(getIframeWindow(iframe), 'postMessage');
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: iframe.contentWindow,
+          data: {
+            jsonrpc: '2.0',
+            id: 'rpc-1',
+            method: 'tools/call',
+            params: {
+              name: 'update_record',
+              arguments: { id: 'record-1', title: 'Updated' },
+            },
+          },
+        }),
+      );
+    });
+
+    expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
+    expect(screen.getAllByText('update_record', { exact: false })).toHaveLength(
+      2,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Allow' }));
+
+    await waitFor(() => {
+      expect(mocks.approve).toHaveBeenCalledWith(
+        'app-1',
+        'approval-1',
+        expect.objectContaining({ token: 'runtime-token' }),
+      );
+      expect(mocks.rpc).toHaveBeenLastCalledWith(
+        'app-1',
+        expect.objectContaining({
+          method: 'tools/call',
+          params: expect.objectContaining({
+            name: 'update_record',
+            approvalId: 'approval-1',
+          }),
+        }),
+        expect.objectContaining({ token: 'runtime-token' }),
+      );
+    });
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'rpc-1', result: expect.any(Object) }),
+      '*',
+    );
+  });
+
+  it('honors App-requested fullscreen mode and allows returning inline', async () => {
+    mocks.rpc.mockResolvedValueOnce({
+      jsonrpc: '2.0',
+      id: 'display-1',
+      result: { mode: 'fullscreen' },
+    });
+
+    const { container } = render(
+      <McpAppMessage data={data} messageId="message-1" />,
+    );
+    const iframe = asIframe(await screen.findByTitle('Example App'));
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: iframe.contentWindow,
+          data: {
+            jsonrpc: '2.0',
+            id: 'display-1',
+            method: 'ui/request-display-mode',
+            params: { mode: 'fullscreen' },
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-display-mode="fullscreen"]'),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Return inline' }));
+    expect(
+      container.querySelector('[data-display-mode="inline"]'),
+    ).toBeInTheDocument();
+  });
+
+  it('advertises standard message modalities, styles, downloads, and pip mode', async () => {
+    render(<McpAppMessage data={data} messageId="message-1" />);
+    const iframe = asIframe(await screen.findByTitle('Example App'));
+    const iframeWindow = getIframeWindow(iframe);
+    const postMessage = vi.spyOn(iframeWindow, 'postMessage');
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: iframeWindow,
+          data: {
+            jsonrpc: '2.0',
+            id: 'initialize-1',
+            method: 'ui/initialize',
+            params: {
+              protocolVersion: '2026-01-26',
+              appCapabilities: {
+                availableDisplayModes: ['inline', 'fullscreen', 'pip'],
+              },
+            },
+          },
+        }),
+      );
+    });
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'initialize-1',
+        result: expect.objectContaining({
+          hostCapabilities: expect.objectContaining({
+            downloadFile: {},
+            message: {
+              text: {},
+              image: {},
+              audio: {},
+              resource: {},
+              resourceLink: {},
+            },
+          }),
+          hostContext: expect.objectContaining({
+            styles: { variables: expect.any(Object) },
+            availableDisplayModes: ['inline', 'fullscreen', 'pip'],
+          }),
+        }),
+      }),
+      '*',
+    );
+  });
+
+  it('preserves multimodal ui/message blocks as text and inline files', async () => {
+    mocks.rpc.mockResolvedValueOnce({
+      jsonrpc: '2.0',
+      id: 'message-1',
+      result: {},
+    });
+
+    render(<McpAppMessage data={data} messageId="message-1" />);
+    const iframe = asIframe(await screen.findByTitle('Example App'));
+    const iframeWindow = getIframeWindow(iframe);
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: iframeWindow,
+          data: {
+            jsonrpc: '2.0',
+            id: 'message-1',
+            method: 'ui/message',
+            params: {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'Describe these' },
+                { type: 'image', data: 'aW1hZ2U=', mimeType: 'image/png' },
+                { type: 'audio', data: 'YXVkaW8=', mimeType: 'audio/wav' },
+                {
+                  type: 'resource',
+                  resource: {
+                    uri: 'mcp://notes/1',
+                    mimeType: 'text/plain',
+                    text: 'Report body',
+                  },
+                },
+                {
+                  type: 'resource',
+                  resource: {
+                    uri: 'mcp://files/archive',
+                    mimeType: 'application/zip',
+                    blob: 'YmluYXJ5',
+                  },
+                },
+                {
+                  type: 'resource_link',
+                  uri: 'mcp://catalog/2',
+                  name: 'Catalog',
+                  description: 'Current catalog',
+                  mimeType: 'text/plain',
+                  size: 42,
+                },
+              ],
+            },
+          },
+        }),
+      );
+    });
+
+    expect(mocks.submit).toHaveBeenCalledWith(
+      {
+        input: {
+          input: expect.stringContaining('Describe these'),
+          files: [
+            expect.objectContaining({
+              name: 'mcp-app-image-2',
+              mimeType: 'image/png',
+              fileUrl: 'data:image/png;base64,aW1hZ2U=',
+            }),
+            expect.objectContaining({
+              name: 'mcp-app-audio-3',
+              mimeType: 'audio/wav',
+              fileUrl: 'data:audio/wav;base64,YXVkaW8=',
+            }),
+            expect.objectContaining({
+              name: 'mcp-app-resource-5',
+              mimeType: 'application/zip',
+              fileUrl: 'data:application/zip;base64,YmluYXJ5',
+            }),
+          ],
+        },
+      },
+      expect.objectContaining({
+        context: expect.objectContaining({
+          mcpApp: expect.objectContaining({ appInstanceId: 'app-1' }),
+        }),
+      }),
+    );
+    const submittedInput = mocks.submit.mock.calls[0]?.[0]?.input?.input;
+    expect(submittedInput).toContain('Report body');
+    expect(submittedInput).toContain('mcp://files/archive');
+    expect(submittedInput).toContain('mcp://catalog/2');
+  });
+
+  it('opens external links only after the audited host RPC accepts them', async () => {
+    mocks.rpc.mockResolvedValueOnce({
+      jsonrpc: '2.0',
+      id: 'link-1',
+      result: {},
+    });
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    render(<McpAppMessage data={data} messageId="message-1" />);
+    const iframe = asIframe(await screen.findByTitle('Example App'));
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: iframe.contentWindow,
+          data: {
+            jsonrpc: '2.0',
+            id: 'link-1',
+            method: 'ui/open-link',
+            params: { href: 'https://docs.example.com/report' },
+          },
+        }),
+      );
+    });
+
+    expect(mocks.rpc).toHaveBeenCalledWith(
+      'app-1',
+      expect.objectContaining({
+        method: 'ui/open-link',
+        params: { url: 'https://docs.example.com/report' },
+      }),
+      expect.objectContaining({ token: expect.any(String) }),
+    );
+    expect(open).toHaveBeenCalledWith(
+      'https://docs.example.com/report',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  it('filters injected CSP directives from remote domain declarations', async () => {
+    render(
+      <McpAppMessage
+        data={{
+          ...data,
+          csp: {
+            connectDomains: [
+              'https://api.example',
+              'https://evil.example;form-action *',
+            ],
+          },
+        }}
+        messageId="message-1"
+      />,
+    );
+
+    const iframe = asIframe(await screen.findByTitle('Example App'));
+    expect(iframe.srcdoc).toContain('connect-src https://api.example');
+    expect(iframe.srcdoc).toContain('form-action https://api.example');
+    expect(iframe.srcdoc).not.toContain('form-action *');
+    expect(iframe.srcdoc).toContain("object-src 'none'");
+  });
+
+  it('uses an approved dedicated sandbox origin through the proxy handshake', async () => {
+    mocks.getResource.mockResolvedValueOnce({
+      uri: data.resourceUri,
+      text: '<!doctype html><html><body>Dedicated App</body></html>',
+      domain: 'weather.mcp-apps.example.com',
+      permissions: { clipboardWrite: {} },
+      toolInput: {},
+      toolInfo: {
+        name: data.toolName,
+        inputSchema: { type: 'object', properties: {} },
+      },
+    });
+
+    render(
+      <McpAppMessage
+        data={data}
+        messageId="message-1"
+        mcpApps={{
+          sandboxProxyUrl:
+            'https://sandbox.mcp-apps.example.com/mcp-app-sandbox-proxy.html',
+          allowedDomains: ['*.mcp-apps.example.com'],
+        }}
+      />,
+    );
+
+    const iframe = asIframe(await screen.findByTitle('Example App'));
+    expect(iframe.src).toContain(
+      'https://weather.mcp-apps.example.com/mcp-app-sandbox-proxy.html',
+    );
+    expect(iframe.srcdoc).toBe('');
+    expect(iframe.getAttribute('sandbox')).toBe(
+      'allow-scripts allow-same-origin',
+    );
+
+    const iframeWindow = getIframeWindow(iframe);
+    const postMessage = vi.spyOn(iframeWindow, 'postMessage');
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: iframeWindow,
+          origin: 'https://weather.mcp-apps.example.com',
+          data: {
+            jsonrpc: '2.0',
+            method: 'ui/notifications/sandbox-proxy-ready',
+            params: {},
+          },
+        }),
+      );
+    });
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'ui/notifications/sandbox-resource-ready',
+        params: expect.objectContaining({
+          html: expect.stringContaining('Dedicated App'),
+          sandbox: 'allow-forms allow-modals allow-scripts allow-same-origin',
+          permissions: { clipboardWrite: {} },
+        }),
+      }),
+      'https://weather.mcp-apps.example.com',
+    );
+  });
+
+  it('downloads files only after the user approves the exact request', async () => {
+    mocks.rpc
+      .mockResolvedValueOnce({
+        jsonrpc: '2.0',
+        id: 'download-1',
+        error: {
+          code: -32001,
+          message: 'Approval required',
+          data: {
+            approvalId: 'approval-download',
+            risk: 'write',
+            expiresAt: Date.now() + 60_000,
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        jsonrpc: '2.0',
+        id: 'download-1',
+        result: {},
+      });
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:https://chat.example/download-1'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+
+    render(<McpAppMessage data={data} messageId="message-1" />);
+    const iframe = asIframe(await screen.findByTitle('Example App'));
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: iframe.contentWindow,
+          data: {
+            jsonrpc: '2.0',
+            id: 'download-1',
+            method: 'ui/download-file',
+            params: {
+              contents: [
+                {
+                  type: 'resource',
+                  resource: {
+                    uri: 'ui://reports/monthly.csv',
+                    mimeType: 'text/csv',
+                    text: 'month,value\nAugust,42',
+                  },
+                },
+              ],
+            },
+          },
+        }),
+      );
+    });
+
+    expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
+    expect(click).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Allow' }));
+
+    await waitFor(() => {
+      expect(mocks.approve).toHaveBeenCalledWith(
+        'app-1',
+        'approval-download',
+        expect.objectContaining({ token: 'runtime-token' }),
+      );
+      expect(click).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('rejects a pending action without retrying the tool call', async () => {
+    mocks.rpc.mockResolvedValueOnce({
+      jsonrpc: '2.0',
+      id: 'rpc-reject',
+      error: {
+        code: -32001,
+        message: 'Approval required',
+        data: {
+          approvalId: 'approval-reject',
+          risk: 'destructive',
+          expiresAt: Date.now() + 60_000,
+        },
+      },
+    });
+
+    render(<McpAppMessage data={data} messageId="message-1" />);
+    const iframe = asIframe(await screen.findByTitle('Example App'));
+    const postMessage = vi.spyOn(getIframeWindow(iframe), 'postMessage');
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: iframe.contentWindow,
+          data: {
+            jsonrpc: '2.0',
+            id: 'rpc-reject',
+            method: 'tools/call',
+            params: {
+              name: 'delete_record',
+              arguments: { id: 'record-1' },
+            },
+          },
+        }),
+      );
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Reject' }));
+
+    await waitFor(() => {
+      expect(mocks.reject).toHaveBeenCalledWith(
+        'app-1',
+        'approval-reject',
+        expect.objectContaining({ token: 'runtime-token' }),
+      );
+    });
+    expect(mocks.rpc).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'rpc-reject',
+        error: expect.objectContaining({ code: -32002 }),
+      }),
+      '*',
+    );
+  });
+
+  it('tears down the server-side App instance after unmount', async () => {
+    const rendered = render(
+      <McpAppMessage data={data} messageId="message-1" />,
+    );
+    const iframe = asIframe(await screen.findByTitle('Example App'));
+    const postMessage = vi.spyOn(getIframeWindow(iframe), 'postMessage');
+
+    rendered.unmount();
+
+    await waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'ui/resource-teardown',
+          params: { reason: 'host-unmount' },
+        }),
+        '*',
+      );
+      expect(mocks.teardown).toHaveBeenCalledWith(
+        'app-1',
+        expect.objectContaining({ token: 'runtime-token' }),
+      );
+    });
+  });
+
+  it('honors app-initiated teardown after notifying the view', async () => {
+    render(<McpAppMessage data={data} messageId="message-1" />);
+    const iframe = asIframe(await screen.findByTitle('Example App'));
+    const iframeWindow = getIframeWindow(iframe);
+    const postMessage = vi.spyOn(iframeWindow, 'postMessage');
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: iframeWindow,
+          data: {
+            jsonrpc: '2.0',
+            method: 'ui/notifications/request-teardown',
+            params: {},
+          },
+        }),
+      );
+    });
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'ui/resource-teardown',
+        params: { reason: 'app-requested' },
+      }),
+      '*',
+    );
+    expect(mocks.teardown).toHaveBeenCalledWith(
+      'app-1',
+      expect.objectContaining({ token: 'runtime-token' }),
+    );
+    expect(screen.queryByTitle('Example App')).not.toBeInTheDocument();
+  });
+});
+
+describe('resolveMcpAppSandboxProxy', () => {
+  const hostLocation = 'https://chat.example.com/thread/1';
+
+  it('fails closed for same-origin or non-http sandbox URLs', () => {
+    expect(
+      resolveMcpAppSandboxProxy(
+        { sandboxProxyUrl: '/mcp-app-sandbox-proxy.html' },
+        undefined,
+        hostLocation,
+      ),
+    ).toBeNull();
+    expect(
+      resolveMcpAppSandboxProxy(
+        { sandboxProxyUrl: 'javascript:alert(1)' },
+        undefined,
+        hostLocation,
+      ),
+    ).toBeNull();
+  });
+
+  it('uses server domains only when the host allowlists them', () => {
+    const options = {
+      sandboxProxyUrl:
+        'https://sandbox.mcp-apps.example.com/mcp-app-sandbox-proxy.html',
+      allowedDomains: ['*.mcp-apps.example.com'],
+    };
+    const approved = resolveMcpAppSandboxProxy(
+      options,
+      'weather.mcp-apps.example.com',
+      hostLocation,
+    );
+    expect(approved).toMatchObject({
+      origin: 'https://weather.mcp-apps.example.com',
+      dedicatedOrigin: true,
+    });
+    expect(approved?.url).toContain(
+      'parentOrigin=https%3A%2F%2Fchat.example.com',
+    );
+
+    const unapproved = resolveMcpAppSandboxProxy(
+      options,
+      'attacker.example.net',
+      hostLocation,
+    );
+    expect(unapproved).toMatchObject({
+      origin: 'https://sandbox.mcp-apps.example.com',
+      dedicatedOrigin: false,
+    });
+  });
+});

--- a/packages/chatkit-ui/src/components/thread/messages/mcp-app.tsx
+++ b/packages/chatkit-ui/src/components/thread/messages/mcp-app.tsx
@@ -2,22 +2,36 @@ import * as React from 'react';
 
 import {
   resolveLocalizedText,
+  type ChatRequestFile,
+  type ChatKitMcpAppsOptions,
   type TMessageComponentMcpAppData,
 } from '@xpert-ai/chatkit-types';
-import { AlertCircle, Loader2 } from 'lucide-react';
+import type { McpAppReviveQuery } from '@xpert-ai/xpert-sdk';
+import {
+  AlertCircle,
+  Loader2,
+  Maximize2,
+  Minimize2,
+  PictureInPicture2,
+  ShieldAlert,
+} from 'lucide-react';
 
 import { useChatkitTranslation } from '../../../i18n/useChatkitTranslation';
 import { cn } from '../../../lib/utils';
 import { useStreamContext } from '../../../providers/Stream';
 import { Badge } from '../../ui/badge';
+import { Button } from '../../ui/button';
 import { IconDefinitionRenderer } from '../../ui/icon-definition';
-
-type JsonRpcRequest = {
-  jsonrpc?: '2.0';
-  id?: string | number | null;
-  method?: string;
-  params?: unknown;
-};
+import {
+  isMcpAppRpcSuccess,
+  readMcpAppDisplayMode,
+  readMcpAppPendingApproval,
+  triggerMcpAppDownloads,
+  withMcpAppApprovalId,
+  type McpAppDisplayMode,
+  type McpAppJsonRpcRequest as JsonRpcRequest,
+  type McpAppPendingApproval,
+} from './mcp-app/host';
 
 type JsonObject = Record<string, unknown>;
 
@@ -79,6 +93,12 @@ type NormalizedMcpAppResource = {
   rawToolResult: unknown;
 };
 
+type ResolvedMcpAppSandboxProxy = {
+  url: string;
+  origin: string;
+  dedicatedOrigin: boolean;
+};
+
 const EMPTY_INPUT_SCHEMA: McpJsonSchemaObject = {
   type: 'object',
   properties: {},
@@ -124,67 +144,29 @@ function readIconDefinition(
 
 function readStringList(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
-  const strings = value.filter((item): item is string => typeof item === 'string');
+  const strings = value.filter(
+    (item): item is string => typeof item === 'string',
+  );
   return strings.length ? strings : undefined;
 }
 
-function buildXpertApiUrl(apiUrl: string, path: string) {
-  const normalizedApiUrl = apiUrl.trim();
-  if (!normalizedApiUrl) return path;
-
-  try {
-    const url = new URL(normalizedApiUrl);
-    return `${url.origin}${path}`;
-  } catch {
-    return path;
-  }
-}
-
-function appendQuery(path: string, params: URLSearchParams) {
-  const query = params.toString();
-  return query ? `${path}?${query}` : path;
-}
-
-function buildMcpAppReviveParams(
+function buildMcpAppReviveQuery(
   data: TMessageComponentMcpAppData,
   options?: {
     appInstanceToken?: string;
     messageId?: string;
   },
-) {
-  const params = new URLSearchParams();
-  const add = (key: string, value?: string) => {
-    if (value) {
-      params.set(key, value);
-    }
+): McpAppReviveQuery {
+  return {
+    toolsetId: data.toolsetId,
+    serverName: data.serverName,
+    toolName: data.toolName,
+    toolCallId: data.toolCallId,
+    resourceUri: data.resourceUri,
+    title: typeof data.title === 'string' ? data.title : undefined,
+    messageId: options?.messageId,
+    token: options?.appInstanceToken ?? data.appInstanceToken,
   };
-
-  add('toolsetId', data.toolsetId);
-  add('serverName', data.serverName);
-  add('toolName', data.toolName);
-  add('toolCallId', data.toolCallId);
-  add('resourceUri', data.resourceUri);
-  add('title', typeof data.title === 'string' ? data.title : undefined);
-  add('messageId', options?.messageId);
-  add('token', options?.appInstanceToken ?? data.appInstanceToken);
-
-  return params;
-}
-
-function buildMcpAppEndpointPath(
-  data: TMessageComponentMcpAppData,
-  endpoint: 'resource' | 'rpc',
-  options?: {
-    appInstanceToken?: string;
-    messageId?: string;
-  },
-) {
-  return appendQuery(
-    `/api/xpert-toolset/mcp-apps/${encodeURIComponent(
-      data.appInstanceId,
-    )}/${endpoint}`,
-    buildMcpAppReviveParams(data, options),
-  );
 }
 
 function escapeHtmlAttribute(value: string) {
@@ -196,7 +178,12 @@ function escapeHtmlAttribute(value: string) {
 }
 
 function domains(values?: string[]) {
-  return values?.filter((value) => value.trim()).join(' ') ?? '';
+  return (
+    values
+      ?.map((value) => value.trim())
+      .filter((value) => value && !/[\s;'"<>]/.test(value))
+      .join(' ') ?? ''
+  );
 }
 
 function buildCsp(csp?: TMessageComponentMcpAppData['csp']) {
@@ -213,7 +200,9 @@ function buildCsp(csp?: TMessageComponentMcpAppData['csp']) {
     `media-src data: blob: ${resourceDomains}`.trim(),
     `font-src data: ${resourceDomains}`.trim(),
     `connect-src ${connectDomains}`,
+    `form-action ${connectDomains}`,
     `frame-src ${frameDomains}`,
+    "object-src 'none'",
     `base-uri ${baseUriDomains}`,
   ].join('; ');
 }
@@ -329,13 +318,19 @@ function jsonRpcResult(id: JsonRpcRequest['id'], result: unknown) {
   };
 }
 
-function jsonRpcError(id: JsonRpcRequest['id'], message: string) {
+function jsonRpcError(
+  id: JsonRpcRequest['id'],
+  message: string,
+  code = -32000,
+  data?: unknown,
+) {
   return {
     jsonrpc: '2.0',
     id: id ?? null,
     error: {
-      code: -32000,
+      code,
       message,
+      ...(data === undefined ? {} : { data }),
     },
   };
 }
@@ -403,11 +398,7 @@ const MCP_APP_THEME_COLOR_TOKENS = [
   ['--background', '--mcp-app-color-background', 'oklch(1 0 0)'],
   ['--foreground', '--mcp-app-color-foreground', 'oklch(0.145 0 0)'],
   ['--card', '--mcp-app-color-card', 'oklch(1 0 0)'],
-  [
-    '--card-foreground',
-    '--mcp-app-color-card-foreground',
-    'oklch(0.145 0 0)',
-  ],
+  ['--card-foreground', '--mcp-app-color-card-foreground', 'oklch(0.145 0 0)'],
   ['--popover', '--mcp-app-color-popover', 'oklch(1 0 0)'],
   [
     '--popover-foreground',
@@ -438,11 +429,7 @@ const MCP_APP_THEME_COLOR_TOKENS = [
     '--mcp-app-color-accent-foreground',
     'oklch(0.205 0 0)',
   ],
-  [
-    '--destructive',
-    '--mcp-app-color-destructive',
-    'oklch(0.577 0.245 27.325)',
-  ],
+  ['--destructive', '--mcp-app-color-destructive', 'oklch(0.577 0.245 27.325)'],
   [
     '--destructive-foreground',
     '--mcp-app-color-destructive-foreground',
@@ -611,13 +598,10 @@ function normalizeMcpAppToolInfo(
       ...rawTool,
       name: originalName,
       title: readLocalizedText(rawTool.title) ?? title,
-      inputSchema: normalizeInputSchema(
-        rawTool.inputSchema ?? raw.inputSchema,
-      ),
+      inputSchema: normalizeInputSchema(rawTool.inputSchema ?? raw.inputSchema),
       ...(description
         ? {
-            description:
-              readLocalizedText(rawTool.description) ?? description,
+            description: readLocalizedText(rawTool.description) ?? description,
           }
         : {}),
       ...(icon ? { icon: readIconDefinition(rawTool.icon) ?? icon } : {}),
@@ -652,9 +636,93 @@ function buildIframeAllow(
 }
 
 function buildSandboxAttribute() {
-  return ['allow-downloads', 'allow-forms', 'allow-modals', 'allow-scripts'].join(
-    ' ',
+  return ['allow-forms', 'allow-modals', 'allow-scripts'].join(' ');
+}
+
+function isLoopbackHostname(hostname: string) {
+  return (
+    hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]'
   );
+}
+
+function normalizeRequestedDomain(value?: string) {
+  const domain = value?.trim().toLowerCase().replace(/\.$/, '');
+  if (!domain || /[/:?#@]/.test(domain)) return null;
+
+  try {
+    const parsed = new URL(`https://${domain}`);
+    return parsed.hostname === domain && !parsed.port ? domain : null;
+  } catch {
+    return null;
+  }
+}
+
+function domainMatchesAllowlist(domain: string, allowedDomains?: string[]) {
+  return Boolean(
+    allowedDomains?.some((value) => {
+      const entry = value.trim().toLowerCase().replace(/\.$/, '');
+      if (entry.startsWith('*.')) {
+        const suffix = entry.slice(2);
+        return (
+          Boolean(suffix) && domain !== suffix && domain.endsWith(`.${suffix}`)
+        );
+      }
+      return domain === entry;
+    }),
+  );
+}
+
+/**
+ * Resolves only host-owned sandbox URLs. A server-provided `ui.domain` may
+ * select an approved hostname, but is never treated as a URL by itself.
+ */
+export function resolveMcpAppSandboxProxy(
+  options: ChatKitMcpAppsOptions | undefined,
+  requestedDomain: string | undefined,
+  hostLocation = window.location.href,
+): ResolvedMcpAppSandboxProxy | null {
+  const configuredUrl = options?.sandboxProxyUrl?.trim();
+  if (!configuredUrl) return null;
+
+  try {
+    const hostOrigin = new URL(hostLocation).origin;
+    const proxyUrl = new URL(configuredUrl, hostLocation);
+    if (
+      proxyUrl.protocol !== 'https:' &&
+      !(proxyUrl.protocol === 'http:' && isLoopbackHostname(proxyUrl.hostname))
+    ) {
+      return null;
+    }
+
+    const domain = normalizeRequestedDomain(requestedDomain);
+    const dedicatedOrigin = Boolean(
+      domain &&
+      (domain === proxyUrl.hostname.toLowerCase() ||
+        domainMatchesAllowlist(domain, options?.allowedDomains)),
+    );
+    if (domain && dedicatedOrigin) {
+      proxyUrl.hostname = domain;
+      proxyUrl.port = '';
+    }
+    if (proxyUrl.origin === hostOrigin) return null;
+
+    const fragment = new URLSearchParams(proxyUrl.hash.slice(1));
+    fragment.set('parentOrigin', hostOrigin);
+    proxyUrl.hash = fragment.toString();
+    return {
+      url: proxyUrl.toString(),
+      origin: proxyUrl.origin,
+      dedicatedOrigin,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function buildMcpAppInnerSandbox(dedicatedOrigin: boolean) {
+  return dedicatedOrigin
+    ? `${buildSandboxAttribute()} allow-same-origin`
+    : buildSandboxAttribute();
 }
 
 function stringifyToolResult(value: unknown) {
@@ -824,27 +892,151 @@ function isHttpUrl(value: string) {
   }
 }
 
-function contentBlocksToText(content: unknown) {
-  if (!Array.isArray(content)) return null;
+const MCP_APP_MESSAGE_MAX_BINARY_BYTES = 25 * 1024 * 1024;
 
-  const parts = content
-    .map((item) => {
-      if (!isRecord(item)) return '';
-      if (item.type === 'text' && typeof item.text === 'string') {
-        return item.text;
-      }
-      if (item.type === 'resource_link' && typeof item.uri === 'string') {
-        return item.uri;
-      }
-      if (item.type === 'image' || item.type === 'audio') {
-        return `[${item.type}]`;
-      }
-      return stringifyToolResult(item);
-    })
-    .map((part) => part.trim())
-    .filter(Boolean);
+type McpAppMessageInput = {
+  input: string;
+  files: ChatRequestFile[];
+};
 
-  return parts.length ? parts.join('\n\n') : null;
+function normalizeMcpMimeType(value: unknown, fallback?: string) {
+  const mimeType = typeof value === 'string' ? value.trim() : fallback;
+  return mimeType &&
+    /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*$/i.test(mimeType)
+    ? mimeType.toLowerCase()
+    : null;
+}
+
+function normalizeMcpBase64(value: unknown) {
+  if (typeof value !== 'string') return null;
+  const data = value.replace(/\s/g, '');
+  if (!data || data.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(data)) {
+    return null;
+  }
+  return data;
+}
+
+function decodedBase64Bytes(data: string) {
+  const padding = data.endsWith('==') ? 2 : data.endsWith('=') ? 1 : 0;
+  return (data.length / 4) * 3 - padding;
+}
+
+function mcpMessageFile(
+  data: string,
+  mimeType: string,
+  name: string,
+): ChatRequestFile {
+  return {
+    name,
+    originalName: name,
+    mimeType,
+    fileUrl: `data:${mimeType};base64,${data}`,
+  };
+}
+
+function resourceLabel(resource: JsonObject) {
+  const details = {
+    uri: readString(resource.uri),
+    mimeType: readString(resource.mimeType),
+  };
+  return `[Resource ${stringifyToolResult(details)}]`;
+}
+
+function resourceLinkLabel(resourceLink: JsonObject) {
+  const details = {
+    uri: readString(resourceLink.uri),
+    name: readString(resourceLink.name),
+    description: readString(resourceLink.description),
+    mimeType: readString(resourceLink.mimeType),
+    size: typeof resourceLink.size === 'number' ? resourceLink.size : undefined,
+  };
+  return `[Resource link ${stringifyToolResult(details)}]`;
+}
+
+function contentBlocksToChatInput(content: unknown): McpAppMessageInput {
+  if (!Array.isArray(content)) {
+    throw new Error('ui/message content must be an array');
+  }
+
+  const text: string[] = [];
+  const files: ChatRequestFile[] = [];
+  let binaryBytes = 0;
+
+  content.forEach((item, index) => {
+    if (!isRecord(item) || typeof item.type !== 'string') {
+      throw new Error(`ui/message content block ${index + 1} is invalid`);
+    }
+
+    if (item.type === 'text') {
+      if (typeof item.text !== 'string') {
+        throw new Error(`ui/message text block ${index + 1} is invalid`);
+      }
+      if (item.text.length) text.push(item.text);
+      return;
+    }
+
+    if (item.type === 'image' || item.type === 'audio') {
+      const mimeType = normalizeMcpMimeType(item.mimeType);
+      const data = normalizeMcpBase64(item.data);
+      if (!mimeType || !data || !mimeType.startsWith(`${item.type}/`)) {
+        throw new Error(
+          `ui/message ${item.type} block ${index + 1} is invalid`,
+        );
+      }
+      binaryBytes += decodedBase64Bytes(data);
+      files.push(
+        mcpMessageFile(data, mimeType, `mcp-app-${item.type}-${index + 1}`),
+      );
+      return;
+    }
+
+    if (item.type === 'resource') {
+      const resource = readRecord(item.resource);
+      if (!resource || typeof resource.uri !== 'string') {
+        throw new Error(`ui/message resource block ${index + 1} is invalid`);
+      }
+      const label = resourceLabel(resource);
+      if (typeof resource.text === 'string') {
+        text.push(`${label}\n${resource.text}`);
+        return;
+      }
+      const data = normalizeMcpBase64(resource.blob);
+      const mimeType = normalizeMcpMimeType(
+        resource.mimeType,
+        'application/octet-stream',
+      );
+      if (!data || !mimeType) {
+        throw new Error(`ui/message resource block ${index + 1} is invalid`);
+      }
+      binaryBytes += decodedBase64Bytes(data);
+      text.push(label);
+      files.push(
+        mcpMessageFile(data, mimeType, `mcp-app-resource-${index + 1}`),
+      );
+      return;
+    }
+
+    if (item.type === 'resource_link' && typeof item.uri === 'string') {
+      text.push(resourceLinkLabel(item));
+      return;
+    }
+
+    throw new Error(
+      `ui/message content block ${index + 1} uses an unsupported type`,
+    );
+  });
+
+  if (binaryBytes > MCP_APP_MESSAGE_MAX_BINARY_BYTES) {
+    throw new Error('ui/message binary content exceeds the 25 MiB limit');
+  }
+  if (!text.length && !files.length) {
+    throw new Error('ui/message content is empty');
+  }
+
+  return {
+    input: text.join('\n\n'),
+    files,
+  };
 }
 
 export function isMcpAppComponentData(
@@ -862,81 +1054,236 @@ export function McpAppMessage({
   data,
   messageId,
   className,
+  mcpApps,
 }: {
   data: TMessageComponentMcpAppData;
   messageId?: string;
   className?: string;
+  mcpApps?: ChatKitMcpAppsOptions;
 }) {
   const { i18n } = useChatkitTranslation();
-  const {
-    apiUrl,
-    authenticatedFetch,
-    isLoading: streamIsLoading,
-    submit,
-  } = useStreamContext();
+  const { client, isLoading: streamIsLoading, submit } = useStreamContext();
   const iframeRef = React.useRef<HTMLIFrameElement>(null);
+  const appWindowRef = React.useRef<Window | null>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
   const initializedRef = React.useRef(false);
   const sentInitialResultRef = React.useRef(false);
   const modelContextRef = React.useRef<unknown>(null);
+  const pendingApprovalRef = React.useRef<McpAppPendingApproval | null>(null);
+  const approvalActionRef = React.useRef<'approve' | 'reject' | null>(null);
+  const runtimeAppInstanceTokenRef = React.useRef<string | undefined>(
+    data.appInstanceToken,
+  );
+  const teardownGenerationRef = React.useRef(0);
+  const teardownStartedRef = React.useRef(false);
+  const activeAppInstanceIdRef = React.useRef(data.appInstanceId);
   const [resource, setResource] =
     React.useState<NormalizedMcpAppResource | null>(null);
-  const [runtimeAppInstanceToken, setRuntimeAppInstanceToken] =
-    React.useState<string | undefined>(data.appInstanceToken);
+  const [runtimeAppInstanceToken, setRuntimeAppInstanceToken] = React.useState<
+    string | undefined
+  >(data.appInstanceToken);
   const [srcDoc, setSrcDoc] = React.useState<string | null>(null);
   const [height, setHeight] = React.useState(420);
+  const [displayMode, setDisplayMode] =
+    React.useState<McpAppDisplayMode>('inline');
+  const [pendingApproval, setPendingApproval] =
+    React.useState<McpAppPendingApproval | null>(null);
+  const [approvalAction, setApprovalAction] = React.useState<
+    'approve' | 'reject' | null
+  >(null);
+  const [approvalError, setApprovalError] = React.useState<string | null>(null);
   const [error, setError] = React.useState<string | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
+  const [isTornDown, setIsTornDown] = React.useState(false);
 
-  const resourceUrl = React.useMemo(
-    () =>
-      buildXpertApiUrl(
-        apiUrl,
-        buildMcpAppEndpointPath(data, 'resource', {
-          messageId,
-        }),
-      ),
-    [apiUrl, data, messageId],
+  const sandboxProxy = React.useMemo(
+    () => resolveMcpAppSandboxProxy(mcpApps, resource?.domain ?? data.domain),
+    [data.domain, mcpApps, resource?.domain],
   );
 
-  const rpcUrl = React.useMemo(
-    () =>
-      buildXpertApiUrl(
-        apiUrl,
-        buildMcpAppEndpointPath(data, 'rpc', {
-          appInstanceToken: runtimeAppInstanceToken,
-          messageId,
-        }),
-      ),
-    [apiUrl, data, messageId, runtimeAppInstanceToken],
+  React.useEffect(() => {
+    runtimeAppInstanceTokenRef.current = runtimeAppInstanceToken;
+  }, [runtimeAppInstanceToken]);
+
+  const bindIframeRef = React.useCallback(
+    (iframe: HTMLIFrameElement | null) => {
+      iframeRef.current = iframe;
+      if (iframe?.contentWindow) {
+        appWindowRef.current = iframe.contentWindow;
+      }
+    },
+    [],
   );
 
-  const postToApp = React.useCallback((message: unknown) => {
-    iframeRef.current?.contentWindow?.postMessage(message, '*');
-  }, []);
+  const postToApp = React.useCallback(
+    (message: unknown) => {
+      iframeRef.current?.contentWindow?.postMessage(
+        message,
+        sandboxProxy?.origin ?? '*',
+      );
+    },
+    [sandboxProxy?.origin],
+  );
 
   const callHostRpc = React.useCallback(
     async (request: JsonRpcRequest) => {
-      const response = await authenticatedFetch(rpcUrl, {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-        },
-        body: JSON.stringify({
+      return client.mcp.apps.rpc(
+        data.appInstanceId,
+        {
           jsonrpc: '2.0',
           id: request.id ?? null,
           method: request.method,
           params: request.params,
+        },
+        buildMcpAppReviveQuery(data, {
+          appInstanceToken: runtimeAppInstanceToken,
+          messageId,
         }),
-      });
+      );
+    },
+    [client, data, messageId, runtimeAppInstanceToken],
+  );
 
-      if (!response.ok) {
-        throw new Error(`MCP App RPC failed with ${response.status}`);
+  const clearPendingApproval = React.useCallback(() => {
+    pendingApprovalRef.current = null;
+    approvalActionRef.current = null;
+    setPendingApproval(null);
+    setApprovalAction(null);
+    setApprovalError(null);
+  }, []);
+
+  const isSupersededStrictModeTeardown = React.useCallback(
+    (generation: number, appInstanceId: string) =>
+      teardownGenerationRef.current !== generation &&
+      activeAppInstanceIdRef.current === appInstanceId,
+    [],
+  );
+
+  const processHostRpcResponse = React.useCallback(
+    (request: JsonRpcRequest, response: unknown) => {
+      const nextApproval = readMcpAppPendingApproval(response, request);
+      if (nextApproval) {
+        if (pendingApprovalRef.current) {
+          postToApp(
+            jsonRpcError(
+              request.id,
+              'Another MCP App approval request is already pending',
+              -32004,
+            ),
+          );
+          return;
+        }
+        pendingApprovalRef.current = nextApproval;
+        setPendingApproval(nextApproval);
+        setApprovalError(null);
+        return;
       }
 
-      return response.json() as Promise<unknown>;
+      const nextDisplayMode = readMcpAppDisplayMode(response);
+      if (request.method === 'ui/request-display-mode' && nextDisplayMode) {
+        setDisplayMode(nextDisplayMode);
+      }
+
+      if (
+        request.method === 'ui/download-file' &&
+        isMcpAppRpcSuccess(response)
+      ) {
+        try {
+          triggerMcpAppDownloads(request.params);
+        } catch (downloadError) {
+          postToApp(
+            jsonRpcError(request.id, getErrorMessage(downloadError), -32005),
+          );
+          return;
+        }
+      }
+
+      postToApp(response);
     },
-    [authenticatedFetch, rpcUrl],
+    [postToApp],
+  );
+
+  const dispatchHostRpc = React.useCallback(
+    async (request: JsonRpcRequest) => {
+      try {
+        processHostRpcResponse(request, await callHostRpc(request));
+      } catch (rpcError) {
+        postToApp(jsonRpcError(request.id, getErrorMessage(rpcError)));
+      }
+    },
+    [callHostRpc, postToApp, processHostRpcResponse],
+  );
+
+  const resolvePendingApproval = React.useCallback(
+    async (action: 'approve' | 'reject') => {
+      const approval = pendingApprovalRef.current;
+      if (!approval || approvalActionRef.current) return;
+      if (approval.expiresAt <= Date.now()) {
+        clearPendingApproval();
+        postToApp(
+          jsonRpcError(
+            approval.request.id,
+            'The MCP App approval request expired',
+            -32003,
+          ),
+        );
+        return;
+      }
+
+      approvalActionRef.current = action;
+      setApprovalAction(action);
+      setApprovalError(null);
+      const query = buildMcpAppReviveQuery(data, {
+        appInstanceToken: runtimeAppInstanceToken,
+        messageId,
+      });
+      try {
+        if (action === 'reject') {
+          await client.mcp.apps.reject(
+            data.appInstanceId,
+            approval.approvalId,
+            query,
+          );
+          clearPendingApproval();
+          postToApp(
+            jsonRpcError(
+              approval.request.id,
+              'The user rejected the MCP App action',
+              -32002,
+              { approvalId: approval.approvalId, rejected: true },
+            ),
+          );
+          return;
+        }
+
+        await client.mcp.apps.approve(
+          data.appInstanceId,
+          approval.approvalId,
+          query,
+        );
+        const retryRequest = withMcpAppApprovalId(
+          approval.request,
+          approval.approvalId,
+        );
+        const response = await callHostRpc(retryRequest);
+        clearPendingApproval();
+        processHostRpcResponse(retryRequest, response);
+      } catch (approvalRequestError) {
+        approvalActionRef.current = null;
+        setApprovalAction(null);
+        setApprovalError(getErrorMessage(approvalRequestError));
+      }
+    },
+    [
+      callHostRpc,
+      clearPendingApproval,
+      client,
+      data,
+      messageId,
+      postToApp,
+      processHostRpcResponse,
+      runtimeAppInstanceToken,
+    ],
   );
 
   const sendInitialToolNotifications = React.useCallback(() => {
@@ -972,7 +1319,16 @@ export function McpAppMessage({
     const controller = new AbortController();
     initializedRef.current = false;
     sentInitialResultRef.current = false;
+    pendingApprovalRef.current = null;
+    approvalActionRef.current = null;
     setRuntimeAppInstanceToken(data.appInstanceToken);
+    runtimeAppInstanceTokenRef.current = data.appInstanceToken;
+    teardownStartedRef.current = false;
+    setIsTornDown(false);
+    setDisplayMode('inline');
+    setPendingApproval(null);
+    setApprovalAction(null);
+    setApprovalError(null);
     setIsLoading(true);
     setError(null);
     setResource(null);
@@ -980,23 +1336,21 @@ export function McpAppMessage({
 
     void (async () => {
       try {
-        const response = await authenticatedFetch(resourceUrl, {
-          signal: controller.signal,
-        });
-        if (!response.ok) {
-          throw new Error(`MCP App resource failed with ${response.status}`);
-        }
-
-        const payload = await response.json();
+        const payload = await client.mcp.apps.getResource(
+          data.appInstanceId,
+          buildMcpAppReviveQuery(data, { messageId }),
+          { signal: controller.signal },
+        );
         const normalizedResource = normalizeMcpAppResourceResponse(
           payload,
           data,
         );
 
         setResource(normalizedResource);
-        setRuntimeAppInstanceToken(
-          normalizedResource.appInstanceToken ?? data.appInstanceToken,
-        );
+        const nextAppInstanceToken =
+          normalizedResource.appInstanceToken ?? data.appInstanceToken;
+        runtimeAppInstanceTokenRef.current = nextAppInstanceToken;
+        setRuntimeAppInstanceToken(nextAppInstanceToken);
         const hostLocale = normalizeHostLocale(i18n.language);
         setSrcDoc(
           injectMcpAppTheme(
@@ -1022,27 +1376,147 @@ export function McpAppMessage({
       controller.abort();
     };
   }, [
-    authenticatedFetch,
+    client,
     data,
     data.appInstanceId,
     data.appInstanceToken,
     data.csp,
     i18n.language,
-    resourceUrl,
+    messageId,
   ]);
+
+  React.useEffect(() => {
+    const generation = ++teardownGenerationRef.current;
+    activeAppInstanceIdRef.current = data.appInstanceId;
+    return () => {
+      const appWindow = appWindowRef.current;
+      const appOrigin = sandboxProxy?.origin ?? '*';
+      const query = buildMcpAppReviveQuery(data, {
+        appInstanceToken: runtimeAppInstanceTokenRef.current,
+        messageId,
+      });
+      const approval = pendingApprovalRef.current;
+      queueMicrotask(() => {
+        if (isSupersededStrictModeTeardown(generation, data.appInstanceId)) {
+          return;
+        }
+        if (teardownStartedRef.current) {
+          return;
+        }
+        teardownStartedRef.current = true;
+        try {
+          appWindow?.postMessage(
+            {
+              jsonrpc: '2.0',
+              id: `xpert-teardown-${data.appInstanceId}`,
+              method: 'ui/resource-teardown',
+              params: { reason: 'host-unmount' },
+            },
+            appOrigin,
+          );
+        } catch {
+          // Detached iframe windows can disappear before React effect cleanup.
+        }
+        void (async () => {
+          if (approval) {
+            await client.mcp.apps
+              .reject(data.appInstanceId, approval.approvalId, query)
+              .catch(() => undefined);
+          }
+          await client.mcp.apps
+            .teardown(data.appInstanceId, query)
+            .catch(() => undefined);
+        })();
+      });
+    };
+  }, [
+    client,
+    data,
+    data.appInstanceId,
+    isSupersededStrictModeTeardown,
+    messageId,
+    sandboxProxy?.origin,
+  ]);
+
+  React.useEffect(() => {
+    if (!pendingApproval) return;
+    const remaining = pendingApproval.expiresAt - Date.now();
+    if (remaining <= 0) {
+      clearPendingApproval();
+      postToApp(
+        jsonRpcError(
+          pendingApproval.request.id,
+          'The MCP App approval request expired',
+          -32003,
+        ),
+      );
+      return;
+    }
+    const timeout = window.setTimeout(() => {
+      if (
+        pendingApprovalRef.current?.approvalId !== pendingApproval.approvalId
+      ) {
+        return;
+      }
+      clearPendingApproval();
+      postToApp(
+        jsonRpcError(
+          pendingApproval.request.id,
+          'The MCP App approval request expired',
+          -32003,
+        ),
+      );
+    }, remaining);
+    return () => window.clearTimeout(timeout);
+  }, [clearPendingApproval, pendingApproval, postToApp]);
 
   React.useEffect(() => {
     sendInitialToolNotifications();
   }, [sendInitialToolNotifications]);
 
   React.useEffect(() => {
+    if (!initializedRef.current) return;
+    postToApp({
+      jsonrpc: '2.0',
+      method: 'ui/notifications/host-context-changed',
+      params: {
+        displayMode,
+        containerDimensions: getContainerDimensions(containerRef.current),
+      },
+    });
+  }, [displayMode, height, postToApp]);
+
+  React.useEffect(() => {
     const handleMessage = async (event: MessageEvent) => {
       if (event.source !== iframeRef.current?.contentWindow) {
+        return;
+      }
+      if (sandboxProxy && event.origin !== sandboxProxy.origin) {
         return;
       }
 
       const request = normalizeJsonRpcMessage(event.data);
       if (!request?.method) {
+        return;
+      }
+
+      if (
+        request.method === 'ui/notifications/sandbox-proxy-ready' &&
+        sandboxProxy &&
+        srcDoc
+      ) {
+        const permissions = resource?.permissions ?? data.permissions;
+        const csp = resource?.csp ?? data.csp;
+        postToApp({
+          jsonrpc: '2.0',
+          method: 'ui/notifications/sandbox-resource-ready',
+          params: {
+            html: srcDoc,
+            sandbox: buildMcpAppInnerSandbox(sandboxProxy.dedicatedOrigin),
+            ...(csp ? { csp } : {}),
+            ...(permissions ? { permissions } : {}),
+          },
+        });
         return;
       }
 
@@ -1059,6 +1533,40 @@ export function McpAppMessage({
             : null;
         if (nextHeight !== null) {
           setHeight(Math.min(900, Math.max(240, Math.round(nextHeight))));
+        }
+        return;
+      }
+
+      if (request.method === 'ui/notifications/request-teardown') {
+        if (teardownStartedRef.current) {
+          return;
+        }
+        teardownStartedRef.current = true;
+        postToApp({
+          jsonrpc: '2.0',
+          id: `xpert-teardown-${data.appInstanceId}`,
+          method: 'ui/resource-teardown',
+          params: { reason: 'app-requested' },
+        });
+        const query = buildMcpAppReviveQuery(data, {
+          appInstanceToken: runtimeAppInstanceTokenRef.current,
+          messageId,
+        });
+        const approval = pendingApprovalRef.current;
+        try {
+          if (approval) {
+            await client.mcp.apps.reject(
+              data.appInstanceId,
+              approval.approvalId,
+              query,
+            );
+          }
+          await client.mcp.apps.teardown(data.appInstanceId, query);
+          clearPendingApproval();
+          setIsTornDown(true);
+        } catch (teardownError) {
+          teardownStartedRef.current = false;
+          setError(getErrorMessage(teardownError));
         }
         return;
       }
@@ -1088,6 +1596,10 @@ export function McpAppMessage({
               logging: {},
               message: {
                 text: {},
+                image: {},
+                audio: {},
+                resource: {},
+                resourceLink: {},
               },
               updateModelContext: {
                 text: {},
@@ -1097,28 +1609,35 @@ export function McpAppMessage({
                 ...(permissions ? { permissions } : {}),
                 ...(csp ? { csp } : {}),
               },
+              downloadFile: {},
             },
             hostContext: {
               toolInfo,
               theme: theme.mode,
+              styles: {
+                variables: theme.cssVariables,
+              },
               themeCssVariables: theme.cssVariables,
               locale: hostLocale,
               language: hostLanguage,
               direction: hostDirection,
               timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-              displayMode: 'inline',
-              availableDisplayModes: ['inline'],
+              displayMode,
+              availableDisplayModes: ['inline', 'fullscreen', 'pip'],
               containerDimensions: getContainerDimensions(containerRef.current),
               userAgent: 'xpert-chatkit',
               platform: 'web',
               deviceCapabilities: {
                 touch: navigator.maxTouchPoints > 0,
-                hover: window.matchMedia('(hover: hover)').matches,
+                hover:
+                  typeof window.matchMedia === 'function'
+                    ? window.matchMedia('(hover: hover)').matches
+                    : false,
               },
             },
             // Legacy compatibility for apps written before the 2026-01-26 result shape.
             capabilities: {
-              displayModes: ['inline'],
+              displayModes: ['inline', 'fullscreen', 'pip'],
               serverTools: true,
               serverResources: true,
               openLinks: true,
@@ -1131,8 +1650,8 @@ export function McpAppMessage({
               language: hostLanguage,
               direction: hostDirection,
               timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-              displayMode: 'inline',
-              availableDisplayModes: ['inline'],
+              displayMode,
+              availableDisplayModes: ['inline', 'fullscreen', 'pip'],
               containerDimensions: getContainerDimensions(containerRef.current),
               userAgent: navigator.userAgent,
               platform: navigator.platform,
@@ -1147,24 +1666,38 @@ export function McpAppMessage({
         const href =
           isRecord(request.params) && typeof request.params.url === 'string'
             ? request.params.url
-            : isRecord(request.params) && typeof request.params.href === 'string'
+            : isRecord(request.params) &&
+                typeof request.params.href === 'string'
               ? request.params.href
               : null;
-        if (href && isHttpUrl(href)) {
-          window.open(href, '_blank', 'noopener,noreferrer');
+        if (!href || !isHttpUrl(href)) {
           if (request.id !== undefined) {
-            postToApp(jsonRpcResult(request.id, {}));
+            postToApp(jsonRpcError(request.id, 'Invalid URL'));
           }
-        } else if (request.id !== undefined) {
-          postToApp(jsonRpcResult(request.id, { isError: true }));
+          return;
+        }
+        try {
+          const response = await callHostRpc({
+            ...request,
+            params: { url: href },
+          });
+          if (isMcpAppRpcSuccess(response)) {
+            window.open(href, '_blank', 'noopener,noreferrer');
+          }
+          postToApp(response);
+        } catch (linkError) {
+          postToApp(jsonRpcError(request.id, getErrorMessage(linkError)));
         }
         return;
       }
 
       if (request.method === 'ui/update-model-context') {
-        modelContextRef.current = request.params;
         try {
-          postToApp(await callHostRpc(request));
+          const response = await callHostRpc(request);
+          if (isMcpAppRpcSuccess(response)) {
+            modelContextRef.current = request.params;
+          }
+          postToApp(response);
         } catch (rpcError) {
           postToApp(jsonRpcError(request.id, getErrorMessage(rpcError)));
         }
@@ -1189,15 +1722,15 @@ export function McpAppMessage({
             return;
           }
 
-          const inputText = contentBlocksToText(request.params.content);
-          if (!inputText) {
-            throw new Error('ui/message content did not include text');
-          }
+          const messageInput = contentBlocksToChatInput(request.params.content);
 
           await submit(
             {
               input: {
-                input: inputText,
+                input: messageInput.input,
+                ...(messageInput.files.length
+                  ? { files: messageInput.files }
+                  : {}),
               },
             },
             {
@@ -1225,11 +1758,7 @@ export function McpAppMessage({
         return;
       }
 
-      try {
-        postToApp(await callHostRpc(request));
-      } catch (rpcError) {
-        postToApp(jsonRpcError(request.id, getErrorMessage(rpcError)));
-      }
+      await dispatchHostRpc(request);
     };
 
     window.addEventListener('message', handleMessage);
@@ -1238,19 +1767,20 @@ export function McpAppMessage({
     };
   }, [
     callHostRpc,
-    data.appInstanceId,
-    data.csp,
-    data.permissions,
-    data.resourceUri,
-    data.title,
-    data.toolCallId,
-    data.toolName,
+    clearPendingApproval,
+    client,
+    data,
+    dispatchHostRpc,
+    displayMode,
     i18n.language,
+    messageId,
     postToApp,
     resource?.csp,
     resource?.permissions,
     resource?.toolInfo,
+    sandboxProxy,
     sendInitialToolNotifications,
+    srcDoc,
     streamIsLoading,
     submit,
   ]);
@@ -1260,9 +1790,10 @@ export function McpAppMessage({
     () => buildIframeAllow(iframePermissions),
     [iframePermissions],
   );
-  const sandbox = React.useMemo(() => buildSandboxAttribute(), []);
-  const prefersBorder =
-    resource?.prefersBorder ?? data.prefersBorder ?? true;
+  const sandbox = sandboxProxy
+    ? 'allow-scripts allow-same-origin'
+    : buildSandboxAttribute();
+  const prefersBorder = resource?.prefersBorder ?? data.prefersBorder ?? true;
   const displayTitle =
     resolveLocalizedText(resource?.title ?? data.title, i18n.language) ??
     data.toolName;
@@ -1271,60 +1802,217 @@ export function McpAppMessage({
     i18n.language,
   );
   const displayIcon = resource?.icon ?? data.icon;
+  const elevatedDisplayMode = displayMode !== 'inline';
+
+  if (isTornDown) {
+    return null;
+  }
 
   return (
-    <div
-      ref={containerRef}
-      className={cn(
-        'overflow-hidden rounded-lg border bg-background shadow-sm',
-        !prefersBorder && 'border-transparent shadow-none',
-        className,
-      )}
-    >
-      <div className="flex min-h-10 items-center justify-between gap-3 border-b px-3 py-2">
-        <div className="flex min-w-0 items-center gap-2">
-          {displayIcon ? (
-            <IconDefinitionRenderer
-              icon={displayIcon}
-              size={18}
-              className="shrink-0"
-              decorative
-            />
-          ) : null}
-          <div className="min-w-0">
-            <div className="truncate text-sm font-medium">{displayTitle}</div>
-            <div className="truncate text-[11px] text-muted-foreground">
-              {displayDescription ?? data.resourceUri}
-            </div>
-          </div>
-        </div>
-        <Badge variant="secondary" className="shrink-0 rounded-md">
-          MCP App
-        </Badge>
-      </div>
-
-      {isLoading ? (
-        <div className="flex h-40 items-center justify-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          <span>{i18n.t('message.mcpApp.loading')}</span>
-        </div>
-      ) : error ? (
-        <div className="flex h-40 items-center justify-center gap-2 px-4 text-sm text-destructive">
-          <AlertCircle className="h-4 w-4 shrink-0" />
-          <span className="min-w-0 break-words">{error}</span>
-        </div>
-      ) : srcDoc ? (
-        <iframe
-          ref={iframeRef}
-          title={displayTitle}
-          srcDoc={srcDoc}
-          className="block w-full bg-background"
-          style={{ height }}
-          sandbox={sandbox}
-          allow={iframeAllow}
-          referrerPolicy="no-referrer"
+    <>
+      {displayMode === 'fullscreen' ? (
+        <div
+          aria-hidden="true"
+          className="fixed inset-0 z-[79] bg-background/80 backdrop-blur-sm"
         />
       ) : null}
-    </div>
+      <div
+        ref={containerRef}
+        data-display-mode={displayMode}
+        className={cn(
+          'relative flex flex-col overflow-hidden rounded-lg border bg-background shadow-sm',
+          displayMode === 'fullscreen' && 'fixed inset-4 z-[80] shadow-2xl',
+          displayMode === 'pip' &&
+            'fixed right-4 bottom-4 z-[80] h-[min(640px,calc(100vh-2rem))] w-[min(480px,calc(100vw-2rem))] shadow-2xl',
+          !prefersBorder && 'border-transparent shadow-none',
+          className,
+        )}
+      >
+        <div className="flex min-h-10 items-center justify-between gap-3 border-b px-3 py-2">
+          <div className="flex min-w-0 items-center gap-2">
+            {displayIcon ? (
+              <IconDefinitionRenderer
+                icon={displayIcon}
+                size={18}
+                className="shrink-0"
+                decorative
+              />
+            ) : null}
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium">{displayTitle}</div>
+              <div className="truncate text-[11px] text-muted-foreground">
+                {displayDescription ?? data.resourceUri}
+              </div>
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            {displayMode !== 'fullscreen' ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                title={i18n.t('message.mcpApp.fullscreen')}
+                aria-label={i18n.t('message.mcpApp.fullscreen')}
+                onClick={() => setDisplayMode('fullscreen')}
+              >
+                <Maximize2 />
+              </Button>
+            ) : null}
+            {displayMode !== 'pip' ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                title={i18n.t('message.mcpApp.pictureInPicture')}
+                aria-label={i18n.t('message.mcpApp.pictureInPicture')}
+                onClick={() => setDisplayMode('pip')}
+              >
+                <PictureInPicture2 />
+              </Button>
+            ) : null}
+            {elevatedDisplayMode ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                title={i18n.t('message.mcpApp.returnInline')}
+                aria-label={i18n.t('message.mcpApp.returnInline')}
+                onClick={() => setDisplayMode('inline')}
+              >
+                <Minimize2 />
+              </Button>
+            ) : null}
+            <Badge variant="secondary" className="ml-1 rounded-md">
+              MCP App
+            </Badge>
+          </div>
+        </div>
+
+        {pendingApproval ? (
+          <div
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby={`mcp-app-approval-${pendingApproval.approvalId}`}
+            className="absolute inset-0 z-20 flex items-center justify-center bg-background/90 p-4 backdrop-blur-sm"
+          >
+            <div className="flex max-h-full w-full max-w-lg flex-col gap-4 overflow-hidden rounded-lg border bg-background p-4 shadow-xl">
+              <div className="flex items-start gap-3">
+                <div className="rounded-full bg-destructive/10 p-2 text-destructive">
+                  <ShieldAlert className="size-5" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3
+                      id={`mcp-app-approval-${pendingApproval.approvalId}`}
+                      className="text-sm font-semibold"
+                    >
+                      {i18n.t('message.mcpApp.approvalTitle')}
+                    </h3>
+                    <Badge
+                      variant="outline"
+                      className="border-destructive/40 text-destructive"
+                    >
+                      {pendingApproval.risk}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {i18n.t(
+                      pendingApproval.kind === 'download'
+                        ? 'message.mcpApp.downloadApprovalDescription'
+                        : 'message.mcpApp.toolApprovalDescription',
+                      { tool: pendingApproval.toolName },
+                    )}
+                  </p>
+                </div>
+              </div>
+
+              <div className="min-h-0">
+                <div className="mb-1 text-xs font-medium">
+                  {i18n.t('message.mcpApp.requestDetails')}
+                </div>
+                <pre className="max-h-48 overflow-auto rounded-md border bg-muted/40 p-3 text-[11px] leading-5 whitespace-pre-wrap break-all">
+                  {pendingApproval.details}
+                </pre>
+              </div>
+
+              {approvalError ? (
+                <div
+                  role="alert"
+                  className="flex items-start gap-2 text-xs text-destructive"
+                >
+                  <AlertCircle className="mt-0.5 size-4 shrink-0" />
+                  <span>{approvalError}</span>
+                </div>
+              ) : null}
+
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={approvalAction !== null}
+                  onClick={() => void resolvePendingApproval('reject')}
+                >
+                  {approvalAction === 'reject' ? (
+                    <Loader2 className="animate-spin" />
+                  ) : null}
+                  {i18n.t('message.mcpApp.reject')}
+                </Button>
+                <Button
+                  type="button"
+                  variant={
+                    pendingApproval.risk === 'destructive'
+                      ? 'destructive'
+                      : 'default'
+                  }
+                  disabled={approvalAction !== null}
+                  onClick={() => void resolvePendingApproval('approve')}
+                >
+                  {approvalAction === 'approve' ? (
+                    <Loader2 className="animate-spin" />
+                  ) : null}
+                  {i18n.t('message.mcpApp.approve')}
+                </Button>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        {isLoading ? (
+          <div
+            className={cn(
+              'flex h-40 items-center justify-center gap-2 text-sm text-muted-foreground',
+              elevatedDisplayMode && 'min-h-0 flex-1',
+            )}
+          >
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>{i18n.t('message.mcpApp.loading')}</span>
+          </div>
+        ) : error ? (
+          <div
+            className={cn(
+              'flex h-40 items-center justify-center gap-2 px-4 text-sm text-destructive',
+              elevatedDisplayMode && 'min-h-0 flex-1',
+            )}
+          >
+            <AlertCircle className="h-4 w-4 shrink-0" />
+            <span className="min-w-0 break-words">{error}</span>
+          </div>
+        ) : srcDoc ? (
+          <iframe
+            ref={bindIframeRef}
+            title={displayTitle}
+            {...(sandboxProxy ? { src: sandboxProxy.url } : { srcDoc })}
+            className={cn(
+              'block w-full bg-background',
+              elevatedDisplayMode && 'min-h-0 flex-1',
+            )}
+            style={elevatedDisplayMode ? undefined : { height }}
+            sandbox={sandbox}
+            allow={iframeAllow}
+            referrerPolicy="no-referrer"
+          />
+        ) : null}
+      </div>
+    </>
   );
 }

--- a/packages/chatkit-ui/src/components/thread/messages/mcp-app/host.test.ts
+++ b/packages/chatkit-ui/src/components/thread/messages/mcp-app/host.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  readMcpAppDisplayMode,
+  readMcpAppPendingApproval,
+  isMcpAppRpcSuccess,
+  triggerMcpAppDownloads,
+  withMcpAppApprovalId,
+} from './host';
+
+describe('MCP App host protocol', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    Reflect.deleteProperty(URL, 'createObjectURL');
+    Reflect.deleteProperty(URL, 'revokeObjectURL');
+  });
+
+  it('recognizes approval-required responses and redacts sensitive details', () => {
+    const request = {
+      jsonrpc: '2.0' as const,
+      id: 'rpc-1',
+      method: 'tools/call',
+      params: {
+        name: 'update_record',
+        arguments: { title: 'Approved title', apiKey: 'secret-value' },
+      },
+    };
+
+    const approval = readMcpAppPendingApproval(
+      {
+        jsonrpc: '2.0',
+        id: 'rpc-1',
+        error: {
+          code: -32001,
+          message: 'Approval required',
+          data: {
+            approvalId: 'approval-1',
+            risk: 'write',
+            expiresAt: Date.now() + 60_000,
+          },
+        },
+      },
+      request,
+    );
+
+    expect(approval).toMatchObject({
+      approvalId: 'approval-1',
+      risk: 'write',
+      toolName: 'update_record',
+      kind: 'tool',
+    });
+    expect(approval?.details).toContain('Approved title');
+    expect(approval?.details).toContain('[Redacted]');
+    expect(approval?.details).not.toContain('secret-value');
+    expect(withMcpAppApprovalId(request, 'approval-1').params).toMatchObject({
+      name: 'update_record',
+      approvalId: 'approval-1',
+    });
+  });
+
+  it('reads all supported display modes from host responses', () => {
+    expect(readMcpAppDisplayMode({ result: { mode: 'pip' } })).toBe('pip');
+    expect(
+      readMcpAppDisplayMode({
+        result: { mode: 'picture-in-picture' },
+      }),
+    ).toBe('pip');
+    expect(readMcpAppDisplayMode({ result: { mode: 'unsupported' } })).toBe(
+      undefined,
+    );
+  });
+
+  it('requires an explicit JSON-RPC result before treating a response as successful', () => {
+    expect(isMcpAppRpcSuccess({ result: {} })).toBe(true);
+    expect(isMcpAppRpcSuccess({})).toBe(false);
+    expect(isMcpAppRpcSuccess({ result: {}, error: {} })).toBe(false);
+  });
+
+  it('summarizes download approvals without exposing embedded file contents', () => {
+    const approval = readMcpAppPendingApproval(
+      {
+        error: {
+          code: -32001,
+          data: {
+            approvalId: 'download-approval',
+            risk: 'write',
+            expiresAt: Date.now() + 60_000,
+          },
+        },
+      },
+      {
+        id: 'download-1',
+        method: 'ui/download-file',
+        params: {
+          contents: [
+            {
+              type: 'resource',
+              resource: {
+                uri: 'ui://reports/private.csv',
+                mimeType: 'text/csv',
+                text: 'sensitive,file,contents',
+              },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(approval?.kind).toBe('download');
+    expect(approval?.details).toContain('private.csv');
+    expect(approval?.details).toContain('bytes');
+    expect(approval?.details).not.toContain('sensitive,file,contents');
+  });
+
+  it('downloads approved embedded resources and HTTP resource links', () => {
+    vi.useFakeTimers();
+    const clicked: Array<{ href: string; filename: string }> = [];
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(
+      function click(this: HTMLAnchorElement) {
+        clicked.push({ href: this.href, filename: this.download });
+      },
+    );
+    const createObjectUrl = vi.fn(() => 'blob:https://chat.example/download-1');
+    const revokeObjectUrl = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectUrl,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectUrl,
+    });
+
+    triggerMcpAppDownloads({
+      contents: [
+        {
+          type: 'resource',
+          resource: {
+            uri: 'ui://reports/monthly.csv',
+            mimeType: 'text/csv',
+            text: 'month,value\nAugust,42',
+          },
+        },
+        {
+          type: 'resource_link',
+          uri: 'https://files.example/report.pdf',
+          name: 'report.pdf',
+        },
+      ],
+    });
+
+    expect(createObjectUrl).toHaveBeenCalledWith(expect.any(Blob));
+    expect(clicked).toEqual([
+      {
+        href: 'blob:https://chat.example/download-1',
+        filename: 'monthly.csv',
+      },
+      {
+        href: 'https://files.example/report.pdf',
+        filename: 'report.pdf',
+      },
+    ]);
+    vi.runAllTimers();
+    expect(revokeObjectUrl).toHaveBeenCalledWith(
+      'blob:https://chat.example/download-1',
+    );
+  });
+});

--- a/packages/chatkit-ui/src/components/thread/messages/mcp-app/host.ts
+++ b/packages/chatkit-ui/src/components/thread/messages/mcp-app/host.ts
@@ -1,0 +1,319 @@
+export type McpAppJsonRpcRequest = {
+  jsonrpc?: '2.0';
+  id?: string | number | null;
+  method?: string;
+  params?: unknown;
+};
+
+export type McpAppDisplayMode = 'inline' | 'fullscreen' | 'pip';
+
+export type McpAppPendingApproval = {
+  approvalId: string;
+  risk: 'write' | 'destructive';
+  expiresAt: number;
+  toolName: string;
+  kind: 'tool' | 'download';
+  request: McpAppJsonRpcRequest;
+  details: string;
+};
+
+function isObject(value: unknown): value is object {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function property(value: object, key: string): unknown {
+  return Reflect.get(value, key);
+}
+
+function stringProperty(value: object, key: string): string | undefined {
+  const field = property(value, key);
+  return typeof field === 'string' && field.trim() ? field.trim() : undefined;
+}
+
+export function getMcpAppRpcErrorCode(value: unknown): number | undefined {
+  if (!isObject(value)) return undefined;
+  const error = property(value, 'error');
+  if (!isObject(error)) return undefined;
+  const code = property(error, 'code');
+  return typeof code === 'number' ? code : undefined;
+}
+
+export function isMcpAppRpcSuccess(value: unknown) {
+  return (
+    isObject(value) &&
+    Reflect.has(value, 'result') &&
+    !Reflect.has(value, 'error')
+  );
+}
+
+export function readMcpAppDisplayMode(
+  value: unknown,
+): McpAppDisplayMode | undefined {
+  if (!isObject(value)) return undefined;
+  const result = property(value, 'result');
+  if (!isObject(result)) return undefined;
+  const mode = property(result, 'mode');
+  if (mode === 'picture-in-picture') return 'pip';
+  return mode === 'inline' || mode === 'fullscreen' || mode === 'pip'
+    ? mode
+    : undefined;
+}
+
+export function readMcpAppPendingApproval(
+  response: unknown,
+  request: McpAppJsonRpcRequest,
+): McpAppPendingApproval | null {
+  if (!isObject(response)) return null;
+  const error = property(response, 'error');
+  if (!isObject(error) || property(error, 'code') !== -32001) return null;
+  const data = property(error, 'data');
+  if (!isObject(data)) return null;
+
+  const approvalId = stringProperty(data, 'approvalId');
+  const risk = property(data, 'risk');
+  const expiresAt = property(data, 'expiresAt');
+  if (
+    !approvalId ||
+    (risk !== 'write' && risk !== 'destructive') ||
+    typeof expiresAt !== 'number' ||
+    !Number.isFinite(expiresAt)
+  ) {
+    return null;
+  }
+
+  const params = isObject(request.params) ? request.params : undefined;
+  const requestedTool = params ? stringProperty(params, 'name') : undefined;
+  const kind = request.method === 'ui/download-file' ? 'download' : 'tool';
+
+  return {
+    approvalId,
+    risk,
+    expiresAt,
+    toolName:
+      kind === 'download'
+        ? 'ui/download-file'
+        : (requestedTool ?? request.method ?? 'tools/call'),
+    kind,
+    request,
+    details:
+      kind === 'download'
+        ? formatDownloadApprovalDetails(request.params)
+        : formatApprovalDetails(request.params),
+  };
+}
+
+export function withMcpAppApprovalId(
+  request: McpAppJsonRpcRequest,
+  approvalId: string,
+): McpAppJsonRpcRequest {
+  return {
+    ...request,
+    params: {
+      ...(isObject(request.params) ? request.params : {}),
+      approvalId,
+    },
+  };
+}
+
+function formatApprovalDetails(value: unknown) {
+  try {
+    const text = JSON.stringify(redactSensitiveValue(value, 0), null, 2);
+    if (!text) return '{}';
+    return text.length > 4_000 ? `${text.slice(0, 4_000)}\n…` : text;
+  } catch {
+    return '[Request details unavailable]';
+  }
+}
+
+function redactSensitiveValue(value: unknown, depth: number): unknown {
+  if (depth >= 6) return '[Nested value omitted]';
+  if (typeof value === 'string' && value.length > 1_000) {
+    return `${value.slice(0, 1_000)}… [${value.length} characters]`;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, 20)
+      .map((item) => redactSensitiveValue(item, depth + 1));
+  }
+  if (!isObject(value)) return value;
+
+  const output: { [key: string]: unknown } = {};
+  for (const [key, field] of Object.entries(value).slice(0, 50)) {
+    output[key] = /password|secret|token|authorization|api[-_]?key/i.test(key)
+      ? '[Redacted]'
+      : redactSensitiveValue(field, depth + 1);
+  }
+  return output;
+}
+
+function formatDownloadApprovalDetails(value: unknown) {
+  if (!isObject(value)) return '{}';
+  const contents = property(value, 'contents');
+  if (!Array.isArray(contents)) return '{}';
+  const summary = contents.slice(0, 20).map((item) => {
+    if (!isObject(item)) return { type: 'invalid' };
+    if (property(item, 'type') === 'resource_link') {
+      return {
+        type: 'resource_link',
+        name: stringProperty(item, 'name'),
+        uri: stringProperty(item, 'uri'),
+        mimeType: stringProperty(item, 'mimeType'),
+      };
+    }
+    const resource = property(item, 'resource');
+    if (!isObject(resource)) return { type: property(item, 'type') };
+    const text = property(resource, 'text');
+    const blob = property(resource, 'blob');
+    return {
+      type: 'resource',
+      name: stringProperty(resource, 'name'),
+      uri: stringProperty(resource, 'uri'),
+      mimeType: stringProperty(resource, 'mimeType'),
+      size:
+        typeof text === 'string'
+          ? `${new TextEncoder().encode(text).byteLength} bytes`
+          : typeof blob === 'string'
+            ? `approximately ${Math.floor((blob.length * 3) / 4)} bytes`
+            : undefined,
+    };
+  });
+  return JSON.stringify({ files: summary }, null, 2);
+}
+
+type DownloadItem =
+  | {
+      kind: 'embedded';
+      filename: string;
+      mimeType: string;
+      text?: string;
+      blob?: string;
+    }
+  | {
+      kind: 'link';
+      filename: string;
+      uri: string;
+    };
+
+export function triggerMcpAppDownloads(value: unknown) {
+  const downloads = parseDownloadItems(value);
+  for (const download of downloads) {
+    if (download.kind === 'link') {
+      clickDownload(download.uri, download.filename);
+      continue;
+    }
+
+    const blob = new Blob(
+      [
+        download.text !== undefined
+          ? download.text
+          : decodeBase64(download.blob ?? ''),
+      ],
+      { type: download.mimeType },
+    );
+    const url = URL.createObjectURL(blob);
+    clickDownload(url, download.filename);
+    window.setTimeout(() => URL.revokeObjectURL(url), 0);
+  }
+}
+
+function parseDownloadItems(value: unknown): DownloadItem[] {
+  if (!isObject(value)) throw new Error('Download params must be an object');
+  if (property(value, 'isError') === true) {
+    throw new Error('The MCP App reported that the download failed');
+  }
+  const contents = property(value, 'contents');
+  if (!Array.isArray(contents) || contents.length === 0) {
+    throw new Error('Download contents must be a non-empty array');
+  }
+
+  return contents.map((item, index) => {
+    if (!isObject(item)) throw new Error('Download content is invalid');
+    const type = property(item, 'type');
+    if (type === 'resource_link') {
+      const uri = stringProperty(item, 'uri');
+      const name = stringProperty(item, 'name');
+      if (!uri || !name || !isHttpUrl(uri)) {
+        throw new Error(
+          'Download link must use HTTP or HTTPS and include a name',
+        );
+      }
+      return {
+        kind: 'link' as const,
+        filename: sanitizeFilename(name, index),
+        uri,
+      };
+    }
+
+    if (type !== 'resource') {
+      throw new Error('Download content type is unsupported');
+    }
+    const resource = property(item, 'resource');
+    if (!isObject(resource)) throw new Error('Embedded download is invalid');
+    const uri = stringProperty(resource, 'uri');
+    if (!uri) throw new Error('Embedded download URI is required');
+    const text = property(resource, 'text');
+    const blob = property(resource, 'blob');
+    if (typeof text !== 'string' && typeof blob !== 'string') {
+      throw new Error('Embedded download must include text or base64 data');
+    }
+    const common = {
+      kind: 'embedded' as const,
+      filename: sanitizeFilename(
+        stringProperty(resource, 'name') ?? filenameFromUri(uri),
+        index,
+      ),
+      mimeType:
+        stringProperty(resource, 'mimeType') ?? 'application/octet-stream',
+    };
+    return typeof text === 'string'
+      ? { ...common, text }
+      : { ...common, blob: blob as string };
+  });
+}
+
+function decodeBase64(value: string) {
+  const decoded = window.atob(value);
+  return Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+}
+
+function filenameFromUri(uri: string) {
+  try {
+    const pathname = new URL(uri).pathname;
+    const segment = pathname.split('/').filter(Boolean).at(-1);
+    return segment ? decodeURIComponent(segment) : 'download';
+  } catch {
+    return uri.split('/').filter(Boolean).at(-1) ?? 'download';
+  }
+}
+
+function sanitizeFilename(value: string, index: number) {
+  const sanitized = Array.from(value, (character) =>
+    character.charCodeAt(0) <= 31 || /[\\/:*?"<>|]/.test(character)
+      ? '_'
+      : character,
+  )
+    .join('')
+    .trim()
+    .slice(0, 255);
+  return sanitized || `download-${index + 1}`;
+}
+
+function isHttpUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function clickDownload(uri: string, filename: string) {
+  const anchor = document.createElement('a');
+  anchor.href = uri;
+  anchor.download = filename;
+  anchor.rel = 'noopener noreferrer';
+  anchor.hidden = true;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+}

--- a/packages/chatkit-ui/src/i18n/locales/en-US.json
+++ b/packages/chatkit-ui/src/i18n/locales/en-US.json
@@ -341,7 +341,16 @@
       "moreTags": "+{{count}}"
     },
     "mcpApp": {
-      "loading": "Loading MCP App"
+      "loading": "Loading MCP App",
+      "fullscreen": "Open fullscreen",
+      "pictureInPicture": "Open picture in picture",
+      "returnInline": "Return inline",
+      "approvalTitle": "Confirm MCP App action",
+      "toolApprovalDescription": "The app wants to run \"{{tool}}\". Review the request before allowing it.",
+      "downloadApprovalDescription": "The app wants to download files to this device. Review the file details before allowing it.",
+      "requestDetails": "Request details",
+      "approve": "Allow",
+      "reject": "Reject"
     },
     "contextCompression": {
       "running": "Automatically compressing context",

--- a/packages/chatkit-ui/src/i18n/locales/zh-CN.json
+++ b/packages/chatkit-ui/src/i18n/locales/zh-CN.json
@@ -341,7 +341,16 @@
       "moreTags": "+{{count}}"
     },
     "mcpApp": {
-      "loading": "正在加载 MCP App"
+      "loading": "正在加载 MCP App",
+      "fullscreen": "全屏显示",
+      "pictureInPicture": "画中画显示",
+      "returnInline": "返回行内显示",
+      "approvalTitle": "确认 MCP App 操作",
+      "toolApprovalDescription": "App 请求运行“{{tool}}”。请检查请求内容后再决定是否允许。",
+      "downloadApprovalDescription": "App 请求将文件下载到此设备。请检查文件详情后再决定是否允许。",
+      "requestDetails": "请求详情",
+      "approve": "允许",
+      "reject": "拒绝"
     },
     "contextCompression": {
       "running": "正在自动压缩上下文",

--- a/packages/chatkit/src/options.ts
+++ b/packages/chatkit/src/options.ts
@@ -512,6 +512,22 @@ export type ChatKitWorkbenchOptions = {
   ) => unknown | Promise<unknown>;
 };
 
+export type ChatKitMcpAppsOptions = {
+  /**
+   * URL of the host-owned MCP Apps sandbox proxy page. Web hosts must serve
+   * this page from an origin different from the ChatKit frame.
+   */
+  sandboxProxyUrl?: string;
+
+  /**
+   * Host-approved dedicated domains. Exact hostnames and leading-wildcard
+   * entries such as `*.mcp-apps.example.com` are supported. A resource's
+   * `ui.domain` is never used unless it matches this list or the configured
+   * proxy URL hostname exactly.
+   */
+  allowedDomains?: string[];
+};
+
 export type ChatKitOptions = {
   /**
    * ChatKit iframe URL for web component integrations.
@@ -580,6 +596,12 @@ export type ChatKitOptions = {
    * @default disabled
    */
   workbench?: ChatKitWorkbenchOptions;
+
+  /**
+   * MCP Apps web-host isolation. When omitted or invalid, ChatKit retains the
+   * credential-isolated opaque-origin iframe fallback.
+   */
+  mcpApps?: ChatKitMcpAppsOptions;
 
   /**
    * Optional animated pet companion rendered by the ChatKit web component over

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,8 +417,8 @@ importers:
         specifier: workspace:~
         version: link:../chatkit-web-shared
       '@xpert-ai/xpert-sdk':
-        specifier: ^0.0.15
-        version: 0.0.15
+        specifier: ^0.0.16
+        version: 0.0.16
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3575,8 +3575,8 @@ packages:
   '@vue/shared@3.5.26':
     resolution: {integrity: sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==}
 
-  '@xpert-ai/xpert-sdk@0.0.15':
-    resolution: {integrity: sha512-l6dRBsmx0R79aygyDrPPeqgf08ABv5XsHYq5fdRuAPJq+df59mR3La4tfRyWW+egL/4aWkYXwtu9ibVu+0iLLA==}
+  '@xpert-ai/xpert-sdk@0.0.16':
+    resolution: {integrity: sha512-MREOMiG2+iNrazLz9ghh9ZLHtBKAeXEdZBFB4p8Km9r+W+tady7xdUau0u9Qz6cCMhWH6MxE2tCxd0Lf8aToMw==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -10504,7 +10504,7 @@ snapshots:
 
   '@vue/shared@3.5.26': {}
 
-  '@xpert-ai/xpert-sdk@0.0.15':
+  '@xpert-ai/xpert-sdk@0.0.16':
     dependencies:
       p-queue: 6.6.2
       p-retry: 4.6.2


### PR DESCRIPTION
## Issue

ChatKit's MCP App renderer called host MCP App endpoints through handwritten request paths. That duplicated the host contract, left lifecycle behavior spread across the component, and could drift from the published Xpert SDK.

## Root cause and user impact

The previous SDK version did not expose the complete MCP App runtime client, so ChatKit owned resource loading and RPC request construction itself. As MCP Apps gained approval, teardown, display-mode, message, and download behavior, keeping those endpoint contracts in ChatKit made upgrades harder and increased the chance that an app worked in the host but failed in ChatKit.

## Fix

- Upgrade `@xpert-ai/xpert-sdk` to `0.0.16` and route MCP App resource, RPC, approval, rejection, and teardown requests through `client.mcp.apps`.
- Add host-side handling for approval-required responses, lifecycle teardown, display modes, model context, messages, downloads, and link requests.
- Add an optional host-owned sandbox proxy and public `mcpApps` configuration for isolated origins and approved dedicated domains.
- Add English and Chinese UI copy plus focused host/component tests.
- Add patch changesets for `@xpert-ai/chatkit-ui` and `@xpert-ai/chatkit-types` because the runtime implementation and public options contract both changed.

## Validation

- `corepack pnpm install --lockfile-only --offline --frozen-lockfile`
- `corepack pnpm --filter @xpert-ai/chatkit-ui test` — 66 files, 503 tests passed
- `corepack pnpm --filter @xpert-ai/chatkit-ui types`
- `corepack pnpm --filter @xpert-ai/chatkit-types types`
- `corepack pnpm --filter @xpert-ai/chatkit-types build`
- `corepack pnpm --filter @xpert-ai/chatkit-ui build`
- Targeted ESLint on the changed TypeScript/React files — 0 errors; 3 existing `setRuntimeCapabilityPalette` dependency warnings remain in `chat.tsx`
- Verified the published `@xpert-ai/xpert-sdk@0.0.16` tarball integrity against the npm registry and compiled ChatKit against that package

## Manual verification

Browser-based MCP App interaction has not been run in this PR worktree and remains for manual acceptance.
